### PR TITLE
Fix: -[AVCaptureSession startRunning] exception

### DIFF
--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
@@ -218,9 +218,7 @@ class PublisherVideoViewController: UIViewController {
         }
         
         // captureSessionのセットアップが完了したので、最後にこのカメラキャプチャが出力する動画の向きを設定します。
-        DispatchQueue.main.async { [weak self] in
-            self?.updateVideoOrientationUsingStatusBarOrientation()
-        }
+        self?.updateVideoOrientationUsingStatusBarOrientation()
         
     }
     


### PR DESCRIPTION
```
2019-04-16 23:30:07.304733+0900 DecoStreamingSample[7509:1366033] *** Terminating app due to uncaught exception 'NSGenericException', reason: '*** -[AVCaptureSession startRunning] startRunning may not be called between calls to beginConfiguration and commitConfiguration'
```

この問題は以下の呼び出しにより発生している:

```
if let connection = output.connection(with: .video) {
    connection.videoOrientation = videoOrientation
}
```

ここで問題になっているのは、 `AVCaptureConnection.videoOrientation` の `set` は `AVCaptureSession` のトランザクション `beginConfiguration()` `commitConfiguration()` が必要で、もしトランザクション外で呼び出されていた場合は暗黙的にトランザクションが生成される点。これを見落としていて、当該箇所をトランザクションの外の main thread で async 実行してしまっているため直後の `AVCaptureSession.startRunning` とタイミングが一致するとこのエラーが発生してしまう。

当該箇所をメインスレッドから呼び出さなければならない理由は恐らく無い (UIApplication.statusBarOrientationに触れているから実装者が念の為気にした?) はずなので、この修正で問題ないと思われる。