### PR TITLE
MediaChannel.mainStream を senderStream もしくは receiverStreams に置き換える

### DIFF
--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
@@ -115,7 +115,7 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
         captureSession.startRunning()
         
         // 配信画面に遷移してきたら、videoViewをvideoRendererに設定することで、配信者側の動画を画面に表示させます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = videoView
+        SoraSDKManager.shared.currentMediaChannel?.senderStream?.videoRenderer = videoView
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -131,7 +131,7 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
         captureSession.stopRunning()
 
         // 配信画面を何らかの理由で抜けることになったら、videoRendererをnilに戻すことで、videoViewへの動画表示をストップさせます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = nil
+        SoraSDKManager.shared.currentMediaChannel?.senderStream?.videoRenderer = nil
     }
     
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -335,7 +335,7 @@ extension PublisherVideoViewController: AVCaptureVideoDataOutputSampleBufferDele
      */
     func captureOutput(_ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         guard let mediaChannel = SoraSDKManager.shared.currentMediaChannel,
-            let mediaStream = mediaChannel.mainStream else {
+            let mediaStream = mediaChannel.senderStream else {
                 return
         }
         if let filter = currentFilter {

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherVideoViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherVideoViewController.swift
@@ -30,14 +30,14 @@ class PublisherVideoViewController: UIViewController {
         
         // 配信画面に遷移してきたら、この画面に遷移してきたということはすでに接続が完了しているということなので、
         // videoViewをvideoRendererに設定することで、配信者側の動画を画面に表示させます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = videoView
+        SoraSDKManager.shared.currentMediaChannel?.senderStream?.videoRenderer = videoView
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         // 配信画面を何らかの理由で抜けることになったら、videoRendererをnilに戻すことで、videoViewへの動画表示をストップさせます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = nil
+        SoraSDKManager.shared.currentMediaChannel?.senderStream?.videoRenderer = nil
     }
     
     /**
@@ -46,10 +46,10 @@ class PublisherVideoViewController: UIViewController {
      */
     @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
         // フロントカメラ・バックカメラを入れ替える処理を行います。
-        guard let mainStream = SoraSDKManager.shared.currentMediaChannel?.mainStream else {
+        guard let senderStream = SoraSDKManager.shared.currentMediaChannel?.senderStream else {
             return
         }
-        guard let cameraVideoCapturer = mainStream.videoCapturer as? CameraVideoCapturer else {
+        guard let cameraVideoCapturer = senderStream.videoCapturer as? CameraVideoCapturer else {
             return
         }
         cameraVideoCapturer.flip()

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberVideoViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberVideoViewController.swift
@@ -30,14 +30,14 @@ class SubscriberVideoViewController: UIViewController {
         
         // 視聴画面に遷移してきたら、この画面に遷移してきたということはすでにmediaSubscriberに接続が完了しているということなので、
         // videoViewをvideoRendererに設定することで、動画を画面に表示させます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = videoView
+        SoraSDKManager.shared.currentMediaChannel?.receiverStreams.first?.videoRenderer = videoView
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         // 視聴画面を何らかの理由で抜けることになったら、videoRendererをnilに戻すことで、videoViewへの動画表示をストップさせます。
-        SoraSDKManager.shared.currentMediaChannel?.mainStream?.videoRenderer = nil
+        SoraSDKManager.shared.currentMediaChannel?.receiverStreams.first?.videoRenderer = nil
     }
     
     /**

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -141,10 +141,10 @@ class GameViewController: UIViewController {
                 return
             }
             guard let currentMediaChannel = SoraSDKManager.shared.currentMediaChannel,
-                let mainStream = currentMediaChannel.mainStream else {
+                let senderStream = currentMediaChannel.senderStream else {
                     return
             }
-            mainStream.send(videoFrame: VideoFrame(from: sampleBuffer))
+            senderStream.send(videoFrame: VideoFrame(from: sampleBuffer))
         }, completionHandler: { [weak self] error in
             if let error = error {
                 // エラーが発生して画面録画が開始できなかった場合は、Soraへの配信を停止する必要があります。


### PR DESCRIPTION
## 変更内容

MediaChannel.mainStream を senderStream もしくは receiverStreams に置き換えました。

マルチストリーム & スポットライトレガシーを有効にしてサンプル・アプリを動かした際、意図しないストリームが選択されて、アプリがクラッシュしてしまうケースがありました。
senderStream, receiverStreams を明示的に指定することで、マルチストリーム & スポットライトレガシーを有効にしてもクラッシュが起きなくなることを確認しています