### PR TITLE
ライトモード時、配信画面でフィルタ選択ピッカーの色が背景色と同色になる事象を修正する

### DIFF
--- a/DecoStreamingSample/DecoStreamingSample/Base.lproj/Main.storyboard
+++ b/DecoStreamingSample/DecoStreamingSample/Base.lproj/Main.storyboard
@@ -150,7 +150,7 @@
                             </view>
                             <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="epT-1s-PRg">
                                 <rect key="frame" x="0.0" y="517" width="375" height="150"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="tintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="150" id="49V-sM-oJj"/>


### PR DESCRIPTION
DecoStreamingSample にて、ライトモード時に配信画面のフィルタ選択ピッカーが背景色と同化して見えにくくなる事象を修正します。ピッカーの背景色に黒が指定されているので、ライト・ダーク両モードに対応するシステムカラーに変更します。