### PR TITLE
デフォルトのチャンネルID を "sora" に設定する

### DIFF
--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
@@ -12,6 +12,16 @@ class PublisherConfigViewController: UITableViewController {
     @IBOutlet var videoCodecSegmentedControl: UISegmentedControl!
     
     /**
+     画面起動時の処理を記述します。
+     */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        channelIdTextField.text = "sora"
+
+    }
+
+    /**
      行がタップされたときの処理を記述します。
      */
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -31,6 +31,9 @@ class SoraSDKManager {
      シングルトンにしたいので、イニシャライザはprivateにしてあります。
      */
     private init() {
+        // SDK のログを表示します。
+        // 送受信されるシグナリングの内容や接続エラーを確認できます。
+        Logger.shared.level = .debug
     }
     
     /**

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherConfigViewController.swift
@@ -12,6 +12,16 @@ class PublisherConfigViewController: UITableViewController {
     @IBOutlet var videoCodecSegmentedControl: UISegmentedControl!
     
     /**
+     画面起動時の処理を記述します。
+     */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        channelIdTextField.text = "sora"
+
+    }
+
+    /**
      行がタップされたときの処理を記述します。
      */
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
@@ -31,6 +31,9 @@ class SoraSDKManager {
      シングルトンにしたいので、イニシャライザはprivateにしてあります。
      */
     private init() {
+        // SDK のログを表示します。
+        // 送受信されるシグナリングの内容や接続エラーを確認できます。
+        Logger.shared.level = .debug
     }
     
     /**

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
@@ -12,6 +12,16 @@ class SubscriberConfigViewController: UITableViewController {
     @IBOutlet var videoCodecSegmentedControl: UISegmentedControl!
     
     /**
+     画面起動時の処理を記述します。
+     */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        channelIdTextField.text = "sora"
+
+    }
+
+    /**
      行がタップされたときの処理を記述します。
      */
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
@@ -12,6 +12,16 @@ class PublisherConfigViewController: UITableViewController {
     @IBOutlet var videoCodecSegmentedControl: UISegmentedControl!
     
     /**
+     画面起動時の処理を記述します。
+     */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        channelIdTextField.text = "sora"
+
+    }
+
+    /**
      行がタップされたときの処理を記述します。
      */
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -31,6 +31,9 @@ class SoraSDKManager {
      シングルトンにしたいので、イニシャライザはprivateにしてあります。
      */
     private init() {
+        // SDK のログを表示します。
+        // 送受信されるシグナリングの内容や接続エラーを確認できます。
+        Logger.shared.level = .debug
     }
     
     /**

--- a/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
@@ -19,6 +19,16 @@ class ConfigViewController: UITableViewController {
     @IBOutlet var spotlightNumberSegmentedControl: UISegmentedControl!
 
     /**
+     画面起動時の処理を記述します。
+     */
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        channelIdTextField.text = "sora"
+
+    }
+
+    /**
      行がタップされたときの処理を記述します。
      */
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
## 概要
以下２点の修正を行っています

- デフォルトのチャンネルID を "sora" に設定する
- debug ログを出力する

## 目的

- サンプル間で挙動を合わせる
- 動作確認操作および異常時の調査を簡易にする

## 修正概要

すでに上記2点が実装されている SimulcastSample, SpotlightSample と同じ修正を行っています
修正対象は以下のとおりです。

- デフォルトのチャンネルID を "sora" に設定する
    - DecoStreamingSample
    - RealTimeStreamingSample
    - ScreenCastSample
    - VideoChatSample
- debug ログを出力する
    - DecoStreamingSample
    - RealTimeStreamingSample
    - ScreenCastSample
