### PR TITLE
DataChannel シグナリングオプションを追加する

### DIFF
--- a/SimulcastSample/SimulcastSample/Base.lproj/Main.storyboard
+++ b/SimulcastSample/SimulcastSample/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -41,7 +42,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="channel_id" textAlignment="right" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ShA-Zi-CkT">
-                                                    <rect key="frame" x="135" y="11" width="220" height="22"/>
+                                                    <rect key="frame" x="135" y="11.5" width="220" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -117,16 +118,90 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection id="2mW-ks-9Aa">
+                            <tableViewSection headerTitle="データチャンネルシグナリング設定" id="2mW-ks-9Aa" userLabel="データチャネルシグナリング設定">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="zhW-aa-tin">
-                                        <rect key="frame" x="0.0" y="349.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="363.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zhW-aa-tin" id="FHd-dF-Glf">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="チャットに入室する" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZQp-k7-8lk">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データチャンネル" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZQp-k7-8lk">
+                                                    <rect key="frame" x="16" y="0.0" width="139" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="UUE-IN-l5i"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Yin-69-X2b" userLabel="Data Channel Signaling Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Yin-69-X2b" secondAttribute="trailing" id="5FA-Pl-IaY"/>
+                                                <constraint firstItem="ZQp-k7-8lk" firstAttribute="top" secondItem="FHd-dF-Glf" secondAttribute="top" id="7hU-ys-8uk"/>
+                                                <constraint firstItem="ZQp-k7-8lk" firstAttribute="leading" secondItem="FHd-dF-Glf" secondAttribute="leadingMargin" id="J0h-0A-Qv6"/>
+                                                <constraint firstItem="Yin-69-X2b" firstAttribute="centerY" secondItem="FHd-dF-Glf" secondAttribute="centerY" id="NC1-5e-WV2"/>
+                                                <constraint firstItem="Yin-69-X2b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ZQp-k7-8lk" secondAttribute="trailing" id="dZF-DU-jXE"/>
+                                                <constraint firstItem="ZQp-k7-8lk" firstAttribute="centerY" secondItem="FHd-dF-Glf" secondAttribute="centerY" id="tPa-UW-Z5P"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="nNp-of-iKv">
+                                        <rect key="frame" x="0.0" y="407.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nNp-of-iKv" id="5WM-B3-sQG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WS 切断を無視" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m43-3j-VWg">
+                                                    <rect key="frame" x="16" y="0.0" width="122" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="EVo-2N-E0l"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="xJE-0n-qMR" userLabel="Ignore Disconnect WebSocket Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="xJE-0n-qMR" secondAttribute="trailing" id="4WD-rw-UAP"/>
+                                                <constraint firstItem="m43-3j-VWg" firstAttribute="top" secondItem="5WM-B3-sQG" secondAttribute="top" id="L8y-Ca-bME"/>
+                                                <constraint firstItem="xJE-0n-qMR" firstAttribute="centerY" secondItem="5WM-B3-sQG" secondAttribute="centerY" id="NfX-fb-uOF"/>
+                                                <constraint firstItem="m43-3j-VWg" firstAttribute="leading" secondItem="5WM-B3-sQG" secondAttribute="leadingMargin" id="Ojv-K6-7zO"/>
+                                                <constraint firstItem="m43-3j-VWg" firstAttribute="centerY" secondItem="5WM-B3-sQG" secondAttribute="centerY" id="emx-pK-IOb"/>
+                                                <constraint firstItem="xJE-0n-qMR" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="m43-3j-VWg" secondAttribute="trailing" id="zDJ-Pi-ve3"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="jyY-Nr-Fab">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="BED-Ai-FrD">
+                                        <rect key="frame" x="0.0" y="487.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="BED-Ai-FrD" id="nyM-DP-OqN">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="チャットに入室する" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="86L-LO-9wN">
                                                     <rect key="frame" x="109.5" y="11.5" width="156" height="21"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -134,8 +209,8 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="ZQp-k7-8lk" firstAttribute="centerX" secondItem="FHd-dF-Glf" secondAttribute="centerX" id="Gcn-4F-Ywz"/>
-                                                <constraint firstItem="ZQp-k7-8lk" firstAttribute="centerY" secondItem="FHd-dF-Glf" secondAttribute="centerY" id="yfV-9p-Y42"/>
+                                                <constraint firstItem="86L-LO-9wN" firstAttribute="centerX" secondItem="nyM-DP-OqN" secondAttribute="centerX" id="PQ8-kL-lh1"/>
+                                                <constraint firstItem="86L-LO-9wN" firstAttribute="centerY" secondItem="nyM-DP-OqN" secondAttribute="centerY" id="aV9-5q-cb3"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -150,6 +225,8 @@
                     <navigationItem key="navigationItem" title="ビデオチャットに参加" id="n9f-bV-9X1"/>
                     <connections>
                         <outlet property="channelIdTextField" destination="ShA-Zi-CkT" id="FYM-h6-rVG"/>
+                        <outlet property="dataChannelSignalingSegmentedControl" destination="Yin-69-X2b" id="QVt-3j-ztI"/>
+                        <outlet property="ignoreDisconnectWebSocketSegmentedControl" destination="xJE-0n-qMR" id="2UT-ca-FfM"/>
                         <outlet property="simulcastRidSegmentedControl" destination="d7C-wH-w61" id="5T2-Ym-WhE"/>
                         <outlet property="videoCodecSegmentedControl" destination="jHA-3S-8CN" id="ftz-Zn-7Ji"/>
                         <segue destination="iOn-KG-Rc0" kind="show" identifier="Connect" id="fwL-7C-azF"/>

--- a/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
@@ -21,6 +21,12 @@ class ConfigViewController: UITableViewController {
         channelIdTextField.text = "sora"
     }
     
+    /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+    @IBOutlet var dataChannelSignalingSegmentedControl: UISegmentedControl!
+    /// データチャンネルシグナリング機能を有効時に WebSoket 切断を許容するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+
+    @IBOutlet var ignoreDisconnectWebSocketSegmentedControl: UISegmentedControl!
+    
     /**
      行がタップされたときの処理を記述します。
      */
@@ -30,7 +36,7 @@ class ConfigViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
         
         // 選択された行が「接続」ボタンでない限り無視します。
-        guard indexPath.section == 3, indexPath.row == 0 else {
+        guard indexPath.section == 4, indexPath.row == 0 else {
             return
         }
         
@@ -56,13 +62,31 @@ class ConfigViewController: UITableViewController {
         default: fatalError()
         }
         
+        let dataChannelSignaling: Bool?
+        switch dataChannelSignalingSegmentedControl.selectedSegmentIndex{
+        case 0: dataChannelSignaling = nil
+        case 1: dataChannelSignaling = false
+        case 2: dataChannelSignaling = true
+        default: fatalError()
+        }
+        
+        let ignoreDisconnectWebSocket: Bool?
+        switch ignoreDisconnectWebSocketSegmentedControl.selectedSegmentIndex{
+        case 0: ignoreDisconnectWebSocket = nil
+        case 1: ignoreDisconnectWebSocket = false
+        case 2: ignoreDisconnectWebSocket = true
+        default: fatalError()
+        }
+        
         // 入力された設定を元にSoraへ接続を行います。
         // ビデオチャットアプリでは複数のユーザーが同時に配信を行う必要があるため、
         // role 引数には .sendrecv を指定し、マルチストリームを有効にします。
         SoraSDKManager.shared.connect(
             channelId: channelId,
             videoCodec: videoCodec,
-            simulcastRid: simulcastRid
+            simulcastRid: simulcastRid,
+            dataChannelSignaling: dataChannelSignaling,
+            ignoreDisconnectWebSocket: ignoreDisconnectWebSocket
         ) { [weak self] error in
             if let error = error {
                 // errorがnilでないばあいは、接続に失敗しています。

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -45,6 +45,8 @@ class SoraSDKManager {
     func connect(channelId: String,
                  videoCodec: VideoCodec,
                  simulcastRid: SimulcastRid?,
+                 dataChannelSignaling: Bool? = nil,
+                 ignoreDisconnectWebSocket: Bool? = nil,
                  completionHandler: ((Error?) -> Void)?) {
         
         // 既にcurrentMediaChannelが設定されている場合は、接続済みとみなし、何もしないで終了します。
@@ -60,6 +62,8 @@ class SoraSDKManager {
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
         configuration.simulcastRid = simulcastRid
+        configuration.dataChannelSignaling = dataChannelSignaling
+        configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
 
         // サイマルキャストを有効にします。
         configuration.simulcastEnabled = true

--- a/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
+++ b/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
@@ -31,21 +31,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
-                        <label key="tableHeaderView" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データチャンネル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jbe-0R-oiz">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="FlZ-pj-rg5"/>
-                            </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <nil key="textColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <sections>
                             <tableViewSection headerTitle="接続設定" id="0Rf-Eq-cRJ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="oj7-Fl-M80">
-                                        <rect key="frame" x="0.0" y="93.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="49.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oj7-Fl-M80" id="FFO-qy-WYA">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -77,7 +67,7 @@
                             <tableViewSection headerTitle="映像コーデック" footerTitle="使用する映像コーデックを選択します。" id="fXu-bU-AWH">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KG5-jM-cSB">
-                                        <rect key="frame" x="0.0" y="195" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="151" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KG5-jM-cSB" id="wuW-MK-FoO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -103,7 +93,7 @@
                             <tableViewSection headerTitle="アクティブ配信数" footerTitle="配信される発声者の最大人数を選択します。" id="PNL-Rl-ZYX">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="Q4z-FJ-AI5">
-                                        <rect key="frame" x="0.0" y="305" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="261" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Q4z-FJ-AI5" id="Wq3-51-LRH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -136,7 +126,7 @@
                             <tableViewSection headerTitle="映像の種類" footerTitle="スポットライト使用時に受信する映像の種類を選択します。" id="2mW-ks-9Aa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="w4c-l2-ytM">
-                                        <rect key="frame" x="0.0" y="415" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="371" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w4c-l2-ytM" id="Umz-ts-ydC">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -172,7 +162,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="K3y-kZ-Rjr">
-                                        <rect key="frame" x="0.0" y="459" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="415" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="K3y-kZ-Rjr" id="ORC-qT-cWy">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -212,7 +202,7 @@
                             <tableViewSection headerTitle="データチャンネルシグナリング設定" id="6PQ-4D-44e">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="QOr-Zy-rST">
-                                        <rect key="frame" x="0.0" y="561.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="517.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QOr-Zy-rST" id="2Np-ls-Sob">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -247,7 +237,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="deb-6W-Di7">
-                                        <rect key="frame" x="0.0" y="605.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="561.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="deb-6W-Di7" id="NV7-2h-fLj">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -286,7 +276,7 @@
                             <tableViewSection id="6GQ-II-yrh">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="OP6-lF-bDi">
-                                        <rect key="frame" x="0.0" y="685.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="641.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OP6-lF-bDi" id="AZP-Dj-9uN">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>

--- a/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
+++ b/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -30,18 +31,28 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
+                        <label key="tableHeaderView" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データチャンネル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jbe-0R-oiz">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="FlZ-pj-rg5"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <sections>
                             <tableViewSection headerTitle="接続設定" id="0Rf-Eq-cRJ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="oj7-Fl-M80">
-                                        <rect key="frame" x="0.0" y="49.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="93.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="oj7-Fl-M80" id="FFO-qy-WYA">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="channel_id" textAlignment="right" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="ShA-Zi-CkT">
-                                                    <rect key="frame" x="118" y="11" width="237" height="22"/>
+                                                    <rect key="frame" x="118" y="11.5" width="237" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits"/>
                                                 </textField>
@@ -66,7 +77,7 @@
                             <tableViewSection headerTitle="映像コーデック" footerTitle="使用する映像コーデックを選択します。" id="fXu-bU-AWH">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="KG5-jM-cSB">
-                                        <rect key="frame" x="0.0" y="151" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="195" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KG5-jM-cSB" id="wuW-MK-FoO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -92,7 +103,7 @@
                             <tableViewSection headerTitle="アクティブ配信数" footerTitle="配信される発声者の最大人数を選択します。" id="PNL-Rl-ZYX">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="Q4z-FJ-AI5">
-                                        <rect key="frame" x="0.0" y="261" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="305" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Q4z-FJ-AI5" id="Wq3-51-LRH">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -125,7 +136,7 @@
                             <tableViewSection headerTitle="映像の種類" footerTitle="スポットライト使用時に受信する映像の種類を選択します。" id="2mW-ks-9Aa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="w4c-l2-ytM">
-                                        <rect key="frame" x="0.0" y="371" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="415" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="w4c-l2-ytM" id="Umz-ts-ydC">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -161,7 +172,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="K3y-kZ-Rjr">
-                                        <rect key="frame" x="0.0" y="415" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="459" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="K3y-kZ-Rjr" id="ORC-qT-cWy">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -198,16 +209,90 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection id="6PQ-4D-44e">
+                            <tableViewSection headerTitle="データチャンネルシグナリング設定" id="6PQ-4D-44e">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="QOr-Zy-rST">
-                                        <rect key="frame" x="0.0" y="503.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="561.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QOr-Zy-rST" id="2Np-ls-Sob">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="チャットに入室する" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PHe-56-ZL6">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データチャンネル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bc5-W6-GoS">
+                                                    <rect key="frame" x="16" y="0.0" width="139" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="P3X-tz-l2r"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="r8Z-CJ-cKv" userLabel="Data Channel Signaling Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="r8Z-CJ-cKv" firstAttribute="centerY" secondItem="2Np-ls-Sob" secondAttribute="centerY" id="2Ev-Fa-7d4"/>
+                                                <constraint firstItem="r8Z-CJ-cKv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Bc5-W6-GoS" secondAttribute="trailing" id="CUv-1V-emv"/>
+                                                <constraint firstItem="Bc5-W6-GoS" firstAttribute="leading" secondItem="2Np-ls-Sob" secondAttribute="leadingMargin" id="T0q-u6-7yo"/>
+                                                <constraint firstItem="Bc5-W6-GoS" firstAttribute="top" secondItem="2Np-ls-Sob" secondAttribute="top" id="djB-fv-Z0i"/>
+                                                <constraint firstItem="Bc5-W6-GoS" firstAttribute="centerY" secondItem="2Np-ls-Sob" secondAttribute="centerY" id="fcp-GJ-J0A"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="r8Z-CJ-cKv" secondAttribute="trailing" id="qEQ-6J-EC3"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="deb-6W-Di7">
+                                        <rect key="frame" x="0.0" y="605.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="deb-6W-Di7" id="NV7-2h-fLj">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WS 切断を無視" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wyw-VD-MfH">
+                                                    <rect key="frame" x="16" y="0.0" width="122" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="I5w-ob-KSz"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="R7z-Gu-4Dp" userLabel="Ignore Disconnect WebSocket Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="R7z-Gu-4Dp" firstAttribute="centerY" secondItem="NV7-2h-fLj" secondAttribute="centerY" id="2Hv-E2-yFc"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="R7z-Gu-4Dp" secondAttribute="trailing" id="BKe-Fv-u66"/>
+                                                <constraint firstItem="Wyw-VD-MfH" firstAttribute="centerY" secondItem="NV7-2h-fLj" secondAttribute="centerY" id="ObW-Zr-Pqm"/>
+                                                <constraint firstItem="Wyw-VD-MfH" firstAttribute="leading" secondItem="NV7-2h-fLj" secondAttribute="leadingMargin" id="oF9-HG-ow0"/>
+                                                <constraint firstItem="Wyw-VD-MfH" firstAttribute="top" secondItem="NV7-2h-fLj" secondAttribute="top" id="r5l-Jh-fWN"/>
+                                                <constraint firstItem="R7z-Gu-4Dp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Wyw-VD-MfH" secondAttribute="trailing" id="sBP-P8-y4v"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="6GQ-II-yrh">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="OP6-lF-bDi">
+                                        <rect key="frame" x="0.0" y="685.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OP6-lF-bDi" id="AZP-Dj-9uN">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="チャットに入室する" textAlignment="center" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vPX-No-0qh">
                                                     <rect key="frame" x="109.5" y="11.5" width="156" height="21"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -215,8 +300,8 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="PHe-56-ZL6" firstAttribute="centerX" secondItem="2Np-ls-Sob" secondAttribute="centerX" id="3f9-Ru-CD9"/>
-                                                <constraint firstItem="PHe-56-ZL6" firstAttribute="centerY" secondItem="2Np-ls-Sob" secondAttribute="centerY" id="ira-gL-YFL"/>
+                                                <constraint firstItem="vPX-No-0qh" firstAttribute="centerY" secondItem="AZP-Dj-9uN" secondAttribute="centerY" id="fi8-F7-VB4"/>
+                                                <constraint firstItem="vPX-No-0qh" firstAttribute="centerX" secondItem="AZP-Dj-9uN" secondAttribute="centerX" id="nrb-sA-W5u"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -231,6 +316,8 @@
                     <navigationItem key="navigationItem" title="スポットライト" id="n9f-bV-9X1"/>
                     <connections>
                         <outlet property="channelIdTextField" destination="ShA-Zi-CkT" id="FYM-h6-rVG"/>
+                        <outlet property="dataChannelSignalingSegmentedControl" destination="r8Z-CJ-cKv" id="Jvi-2O-gb5"/>
+                        <outlet property="ignoreDisconnectWebSocketSegmentedControl" destination="R7z-Gu-4Dp" id="AoY-MD-GUH"/>
                         <outlet property="spotlightFocusRidSegmentedControl" destination="S3w-p8-QFj" id="8Kp-cT-pz2"/>
                         <outlet property="spotlightNumberSegmentedControl" destination="d7C-wH-w61" id="Be1-cJ-j36"/>
                         <outlet property="spotlightUnfocusRidSegmentedControl" destination="cWJ-SD-e0P" id="akT-r2-u51"/>

--- a/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
@@ -27,6 +27,12 @@ class ConfigViewController: UITableViewController {
         channelIdTextField.text = "sora"
     }
     
+    /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+    @IBOutlet var dataChannelSignalingSegmentedControl: UISegmentedControl!
+    
+    /// データチャンネルシグナリング機能を有効時に WebSoket 切断を許容するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+    @IBOutlet var ignoreDisconnectWebSocketSegmentedControl: UISegmentedControl!
+    
     /**
      行がタップされたときの処理を記述します。
      */
@@ -36,7 +42,7 @@ class ConfigViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
         
         // 選択された行が「接続」ボタンでない限り無視します。
-        guard indexPath.section == 4, indexPath.row == 0 else {
+        guard indexPath.section == 5, indexPath.row == 0 else {
             return
         }
         
@@ -80,6 +86,22 @@ class ConfigViewController: UITableViewController {
             spotlightNumber = spotlightNumberSegmentedControl.selectedSegmentIndex
         }
 
+        let dataChannelSignaling: Bool?
+        switch dataChannelSignalingSegmentedControl.selectedSegmentIndex{
+        case 0: dataChannelSignaling = nil
+        case 1: dataChannelSignaling = false
+        case 2: dataChannelSignaling = true
+        default: fatalError()
+        }
+        
+        let ignoreDisconnectWebSocket: Bool?
+        switch ignoreDisconnectWebSocketSegmentedControl.selectedSegmentIndex{
+        case 0: ignoreDisconnectWebSocket = nil
+        case 1: ignoreDisconnectWebSocket = false
+        case 2: ignoreDisconnectWebSocket = true
+        default: fatalError()
+        }
+        
         // 入力された設定を元にSoraへ接続を行います。
         // ビデオチャットアプリでは複数のユーザーが同時に配信を行う必要があるため、
         // role 引数には .sendrecv を指定し、マルチストリームを有効にします。
@@ -88,7 +110,9 @@ class ConfigViewController: UITableViewController {
             videoCodec: videoCodec,
             spotlightFocusRid: spotlightFocusRid,
             spotlightUnfocusRid: spotlightUnfocusRid,
-            spotlightNumber: spotlightNumber
+            spotlightNumber: spotlightNumber,
+            dataChannelSignaling: dataChannelSignaling,
+            ignoreDisconnectWebSocket: ignoreDisconnectWebSocket
         ) { [weak self] error in
             if let error = error {
                 // errorがnilでないばあいは、接続に失敗しています。

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -47,6 +47,8 @@ class SoraSDKManager {
                  spotlightFocusRid: SpotlightRid,
                  spotlightUnfocusRid: SpotlightRid,
                  spotlightNumber: Int?,
+                 dataChannelSignaling: Bool? = nil,
+                 ignoreDisconnectWebSocket: Bool? = nil,
                  completionHandler: ((Error?) -> Void)?) {
         
         // 既にcurrentMediaChannelが設定されている場合は、接続済みとみなし、何もしないで終了します。
@@ -64,6 +66,8 @@ class SoraSDKManager {
         configuration.spotlightFocusRid = spotlightFocusRid
         configuration.spotlightUnfocusRid = spotlightUnfocusRid
         configuration.spotlightNumber = spotlightNumber
+        configuration.dataChannelSignaling = dataChannelSignaling
+        configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
 
         // スポットライトを有効にします。
         configuration.spotlightEnabled = .enabled

--- a/VideoChatSample/Podfile
+++ b/VideoChatSample/Podfile
@@ -5,5 +5,5 @@ platform :ios, '12.1'
 
 target 'VideoChatSample' do
   use_frameworks!
-  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'feature/data-channel-signaling'
+  pod 'Sora', '2021.2.1'
 end

--- a/VideoChatSample/Podfile
+++ b/VideoChatSample/Podfile
@@ -5,5 +5,5 @@ platform :ios, '12.1'
 
 target 'VideoChatSample' do
   use_frameworks!
-  pod 'Sora', '2021.2.1'
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'feature/data-channel-signaling'
 end

--- a/VideoChatSample/VideoChatSample/Base.lproj/Main.storyboard
+++ b/VideoChatSample/VideoChatSample/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -92,10 +92,84 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="データチャネルシグナリング設定" id="dEy-Xn-hbH">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="pss-Dg-3Qx">
+                                        <rect key="frame" x="0.0" y="253.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pss-Dg-3Qx" id="SG3-bc-GMK">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="データチャンネル" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ngB-LY-InH">
+                                                    <rect key="frame" x="16" y="0.0" width="139" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="kFV-xq-JYi"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="0J6-my-JRG" userLabel="Data Channel Signaling Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="0J6-my-JRG" secondAttribute="trailing" id="ANW-4b-e3F"/>
+                                                <constraint firstItem="ngB-LY-InH" firstAttribute="leading" secondItem="SG3-bc-GMK" secondAttribute="leadingMargin" id="CMt-Qi-QW2"/>
+                                                <constraint firstItem="0J6-my-JRG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ngB-LY-InH" secondAttribute="trailing" id="HgM-DT-20J"/>
+                                                <constraint firstItem="0J6-my-JRG" firstAttribute="centerY" secondItem="SG3-bc-GMK" secondAttribute="centerY" id="LGJ-U3-Ngh"/>
+                                                <constraint firstItem="ngB-LY-InH" firstAttribute="top" secondItem="SG3-bc-GMK" secondAttribute="top" id="ZXf-4W-aAb"/>
+                                                <constraint firstItem="ngB-LY-InH" firstAttribute="centerY" secondItem="SG3-bc-GMK" secondAttribute="centerY" id="fM5-X2-1Fe"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Azl-WD-kPA">
+                                        <rect key="frame" x="0.0" y="297.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Azl-WD-kPA" id="r0R-1J-fmS">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WS 切断を無視" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="234-Pi-C4P">
+                                                    <rect key="frame" x="16" y="0.0" width="122" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="122" id="zwb-b5-E9q"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="tOw-iP-1q2" userLabel="Ignore Disconnect WebSocket Segmented Control">
+                                                    <rect key="frame" x="183" y="6.5" width="176" height="32"/>
+                                                    <segments>
+                                                        <segment title="未指定"/>
+                                                        <segment title="無効"/>
+                                                        <segment title="有効"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="tOw-iP-1q2" secondAttribute="trailing" id="6qT-2y-Icj"/>
+                                                <constraint firstItem="234-Pi-C4P" firstAttribute="centerY" secondItem="r0R-1J-fmS" secondAttribute="centerY" id="OhZ-NK-Ze5"/>
+                                                <constraint firstItem="tOw-iP-1q2" firstAttribute="centerY" secondItem="r0R-1J-fmS" secondAttribute="centerY" id="P0E-FH-8i1"/>
+                                                <constraint firstItem="tOw-iP-1q2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="234-Pi-C4P" secondAttribute="trailing" id="d7c-8L-EYe"/>
+                                                <constraint firstItem="234-Pi-C4P" firstAttribute="top" secondItem="r0R-1J-fmS" secondAttribute="top" id="hCh-2Y-6t2"/>
+                                                <constraint firstItem="234-Pi-C4P" firstAttribute="leading" secondItem="r0R-1J-fmS" secondAttribute="leadingMargin" id="hYO-d0-gCY"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="スポットライトレガシー設定" footerTitle="スポットライトレガシーの設定を選択します。ビデオコーデックは VP8 または H.264 のみ有効です。" id="9vd-10-yNj">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="XSC-pL-hI1">
-                                        <rect key="frame" x="0.0" y="261" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="399" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XSC-pL-hI1" id="v4h-Af-Wxb">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -121,7 +195,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="q8d-Ms-ucJ">
-                                        <rect key="frame" x="0.0" y="305" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="443" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="q8d-Ms-ucJ" id="TpD-aM-WKr">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -157,7 +231,7 @@
                             <tableViewSection id="2mW-ks-9Aa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="zhW-aa-tin">
-                                        <rect key="frame" x="0.0" y="407.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="545.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zhW-aa-tin" id="FHd-dF-Glf">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -187,6 +261,8 @@
                     <navigationItem key="navigationItem" title="ビデオチャットに参加" id="n9f-bV-9X1"/>
                     <connections>
                         <outlet property="channelIdTextField" destination="ShA-Zi-CkT" id="FYM-h6-rVG"/>
+                        <outlet property="dataChannelSignalingSegmentedControl" destination="0J6-my-JRG" id="yFu-Fl-Kqh"/>
+                        <outlet property="ignoreDisconnectWebSocketSegmentedControl" destination="tOw-iP-1q2" id="xYM-Gk-rTD"/>
                         <outlet property="spotlightLegacySwitch" destination="ppP-bz-VWD" id="5Th-xY-5AA"/>
                         <outlet property="spotlightNumberSegmentedControl" destination="Caw-IX-pf0" id="2kq-oZ-8OL"/>
                         <outlet property="videoCodecSegmentedControl" destination="jHA-3S-8CN" id="ftz-Zn-7Ji"/>
@@ -195,7 +271,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LEb-Vr-gaU" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1017" y="166"/>
+            <point key="canvasLocation" x="1016.8" y="165.06746626686657"/>
         </scene>
         <!--チャット中: channel_id-->
         <scene sceneID="hlW-Xb-Uw7">

--- a/VideoChatSample/VideoChatSample/Base.lproj/Main.storyboard
+++ b/VideoChatSample/VideoChatSample/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uhR-pc-WPX">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -92,7 +92,7 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="データチャネルシグナリング設定" id="dEy-Xn-hbH">
+                            <tableViewSection headerTitle="データチャンネルシグナリング設定" id="dEy-Xn-hbH">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="pss-Dg-3Qx">
                                         <rect key="frame" x="0.0" y="253.5" width="375" height="44"/>

--- a/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
@@ -12,6 +12,12 @@ class ConfigViewController: UITableViewController {
     /// 動画のコーデックを指定するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
     @IBOutlet var videoCodecSegmentedControl: UISegmentedControl!
 
+    /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+    @IBOutlet var dataChannelSignalingSegmentedControl: UISegmentedControl!
+    
+    /// データチャンネルシグナリング機能を有効時に WebSoket 切断を許容するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
+    @IBOutlet var ignoreDisconnectWebSocketSegmentedControl: UISegmentedControl!
+    
     /// スポットライトレガシー機能を指定するためのスイッチです。 Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
     @IBOutlet var spotlightLegacySwitch: UISwitch!
 
@@ -37,7 +43,7 @@ class ConfigViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
         
         // 選択された行が「接続」ボタンでない限り無視します。
-        guard indexPath.section == 3, indexPath.row == 0 else {
+        guard indexPath.section == 4, indexPath.row == 0 else {
             return
         }
         
@@ -53,6 +59,22 @@ class ConfigViewController: UITableViewController {
         case 1: videoCodec = .vp9
         case 2: videoCodec = .vp8
         case 3: videoCodec = .h264
+        default: fatalError()
+        }
+        
+        let dataChannelSignaling: Bool?
+        switch dataChannelSignalingSegmentedControl.selectedSegmentIndex{
+        case 0: dataChannelSignaling = nil
+        case 1: dataChannelSignaling = false
+        case 2: dataChannelSignaling = true
+        default: fatalError()
+        }
+
+        let ignoreDisconnectWebSocket: Bool?
+        switch ignoreDisconnectWebSocketSegmentedControl.selectedSegmentIndex{
+        case 0: ignoreDisconnectWebSocket = nil
+        case 1: ignoreDisconnectWebSocket = false
+        case 2: ignoreDisconnectWebSocket = true
         default: fatalError()
         }
         
@@ -76,6 +98,8 @@ class ConfigViewController: UITableViewController {
             role: .sendrecv,
             multistreamEnabled: true,
             videoCodec: videoCodec,
+            dataChannelSignaling: dataChannelSignaling,
+            ignoreDisconnectWebSocket: ignoreDisconnectWebSocket,
             spotlight: spotlight,
             spotlightNumber: spotlightNumber
         ) { [weak self] error in

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -46,6 +46,8 @@ class SoraSDKManager {
                  role: Role,
                  multistreamEnabled: Bool,
                  videoCodec: VideoCodec = .default,
+                 dataChannelSignaling: Bool? = nil,
+                 ignoreDisconnectWebSocket: Bool? = nil,
                  spotlight: Configuration.Spotlight = .disabled,
                  spotlightNumber: Int? = nil,
                  completionHandler: ((Error?) -> Void)?) {
@@ -63,6 +65,8 @@ class SoraSDKManager {
         
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
+        configuration.dataChannelSignaling = dataChannelSignaling
+        configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
         configuration.spotlightEnabled = spotlight
         configuration.spotlightNumber = spotlightNumber
         


### PR DESCRIPTION
VideoChatSample, SpotlightSample, SimulcastSampleに DataChannel のシグナリングオプションの2項目を追加しました。


---
--- 以下、過去の内容 ---

VideoChatSample に DataChannel のシグナリングオプションの2項目を追加しました。

- dataChannelSignaling
- ignoreDisconnectWebSocket

スポットライトレガシーは廃止予定なので、スポットライトレガシー設定の上に項目を配置しています。
すでにある項目を参考に作成していますがおかしなところがないか確認をお願いできますか。

問題がなければ SpotlightSample, SimulcastSample に展開しようと思います。
→展開しました