### PR TITLE
ローカルな設定を Environment.swift にまとめる

### DIFF
--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp DecoStreamingSample/Environment.example.swift DecoStreamingSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/realtime-streaming-sample.yml
+++ b/.github/workflows/realtime-streaming-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp RealTimeStreamingSample/Environment.example.swift RealTimeStreamingSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp ScreenCastSample/Environment.example.swift ScreenCastSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp SimulcastSample/Environment.example.swift SimulcastSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp SpotlightSample/Environment.example.swift SpotlightSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         pod repo update
         pod install
+    - name: Create Environment.swift
+      run: |
+        cp VideoChatSample/Environment.example.swift VideoChatSample/Environment.swift
     - name: Build Xcode Project
       run: |
         set -o pipefail && \

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ DerivedData
 !default.perspectivev3
 xcuserdata
 project.xcworkspace
+Environment.swift
 
 ## Other
 .DS_Store

--- a/DecoStreamingSample/DecoStreamingSample.xcodeproj/project.pbxproj
+++ b/DecoStreamingSample/DecoStreamingSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35DC8E9627A38699000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E9527A38699000B0ED7 /* Environment.swift */; };
 		9120C49E23B3502B0026176E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9120C49D23B3502B0026176E /* AppDelegate.swift */; };
 		9120C4A523B3502B0026176E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9120C4A323B3502B0026176E /* Main.storyboard */; };
 		9120C4A723B3502C0026176E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9120C4A623B3502C0026176E /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		35DC8E9527A38699000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		9120C49A23B3502B0026176E /* DecoStreamingSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DecoStreamingSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9120C49D23B3502B0026176E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9120C4A423B3502B0026176E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 				9120C4B623B3505A0026176E /* Classes */,
 				9120C4BD23B3505A0026176E /* InfoPlist.strings */,
 				9120C49D23B3502B0026176E /* AppDelegate.swift */,
+				35DC8E9527A38699000B0ED7 /* Environment.swift */,
 				9120C4A323B3502B0026176E /* Main.storyboard */,
 				9120C4A623B3502C0026176E /* Assets.xcassets */,
 				9120C4A823B3502C0026176E /* LaunchScreen.storyboard */,
@@ -223,6 +226,7 @@
 				9120C4C123B3505A0026176E /* AVCaptureVideoPreviewView.swift in Sources */,
 				9120C4C423B3505A0026176E /* SoraSDKManager.swift in Sources */,
 				9120C49E23B3502B0026176E /* AppDelegate.swift in Sources */,
+				35DC8E9627A38699000B0ED7 /* Environment.swift in Sources */,
 				9120C4C323B3505A0026176E /* PublisherVideoViewController.swift in Sources */,
 				9120C4C023B3505A0026176E /* AVCaptureVideoOrientation+Extension.swift in Sources */,
 				9120C4C223B3505A0026176E /* PublisherConfigViewController.swift in Sources */,

--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
@@ -16,7 +16,7 @@ class PublisherConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /**

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -55,7 +48,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定は URL、チャネル ID、ロール、マルチストリームの可否です。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL,
+        var configuration = Configuration(url: Environment.url,
                                           channelId: channelId,
                                           role: role,
                                           multistreamEnabled: multistreamEnabled)

--- a/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}

--- a/DecoStreamingSample/README.md
+++ b/DecoStreamingSample/README.md
@@ -16,15 +16,19 @@ Sora iOS SDK を用いて実装する方法を説明しています。
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``DecoStreamingSample/Environment.example.swift`` のファイル名を ``DecoStreamingSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp DecoStreamingSample/Environment.example.swift DecoStreamingSample/Environment.swift
+   ```
+
+３. ``DecoStreamingSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/RealTimeStreamingSample/README.md
+++ b/RealTimeStreamingSample/README.md
@@ -15,15 +15,19 @@
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``RealTimeStreamingSample/Environment.example.swift`` のファイル名を ``RealTimeStreamingSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp RealTimeStreamingSample/Environment.example.swift RealTimeStreamingSample/Environment.swift
+   ```
+
+３. ``RealTimeStreamingSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/RealTimeStreamingSample/RealTimeStreamingSample.xcodeproj/project.pbxproj
+++ b/RealTimeStreamingSample/RealTimeStreamingSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35DC8E9827A386BD000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E9727A386BD000B0ED7 /* Environment.swift */; };
 		91D7575F23B487A3007BFB81 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D7575E23B487A3007BFB81 /* AppDelegate.swift */; };
 		91D7576623B487A3007BFB81 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 91D7576423B487A3007BFB81 /* Main.storyboard */; };
 		91D7576823B487A5007BFB81 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 91D7576723B487A5007BFB81 /* Assets.xcassets */; };
@@ -24,6 +25,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		35DC8E9727A386BD000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		91D7575B23B487A3007BFB81 /* RealTimeStreamingSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RealTimeStreamingSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91D7575E23B487A3007BFB81 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		91D7576523B487A3007BFB81 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 				91D7576C23B487A5007BFB81 /* Info.plist */,
 				91D7577E23B487E7007BFB81 /* InfoPlist.strings */,
 				91D7575E23B487A3007BFB81 /* AppDelegate.swift */,
+				35DC8E9727A386BD000B0ED7 /* Environment.swift */,
 				91D7577F23B487E7007BFB81 /* Assets.xcassets */,
 				91D7577923B487E7007BFB81 /* Base.lproj */,
 				91D7577223B487E7007BFB81 /* Classes */,
@@ -224,6 +227,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				91D7578423B487E7007BFB81 /* SubscriberConfigViewController.swift in Sources */,
+				35DC8E9827A386BD000B0ED7 /* Environment.swift in Sources */,
 				91D7578023B487E7007BFB81 /* MainMenuViewController.swift in Sources */,
 				91D7578323B487E7007BFB81 /* SoraSDKManager.swift in Sources */,
 				91D7575F23B487A3007BFB81 /* AppDelegate.swift in Sources */,

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -54,7 +47,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL, channelId: channelId, role: role)
+        var configuration = Configuration(url: Environment.url, channelId: channelId, role: role)
 
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
@@ -16,7 +16,7 @@ class SubscriberConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /**

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}

--- a/ScreenCastSample/README.md
+++ b/ScreenCastSample/README.md
@@ -15,15 +15,19 @@
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``ScreenCastSample/Environment.example.swift`` のファイル名を ``ScreenCastSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp ScreenCastSample/Environment.example.swift ScreenCastSample/Environment.swift
+   ```
+
+３. ``ScreenCastSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/ScreenCastSample/ScreenCastSample.xcodeproj/project.pbxproj
+++ b/ScreenCastSample/ScreenCastSample.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35DC8E9A27A386DB000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E9927A386DB000B0ED7 /* Environment.swift */; };
 		9120C46123B342960026176E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9120C46023B342960026176E /* AppDelegate.swift */; };
 		9120C46823B342960026176E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9120C46623B342960026176E /* Main.storyboard */; };
 		9120C46A23B342970026176E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9120C46923B342970026176E /* Assets.xcassets */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		35DC8E9927A386DB000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		9120C45D23B342960026176E /* ScreenCastSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ScreenCastSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9120C46023B342960026176E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9120C46723B342960026176E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				9120C48123B343B60026176E /* Classes */,
 				9120C47723B343A40026176E /* InfoPlist.strings */,
 				9120C46023B342960026176E /* AppDelegate.swift */,
+				35DC8E9927A386DB000B0ED7 /* Environment.swift */,
 				9120C46623B342960026176E /* Main.storyboard */,
 				9120C46923B342970026176E /* Assets.xcassets */,
 				9120C46B23B342970026176E /* LaunchScreen.storyboard */,
@@ -230,6 +233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9120C48923B343B60026176E /* GameViewController.swift in Sources */,
+				35DC8E9A27A386DB000B0ED7 /* Environment.swift in Sources */,
 				9120C48C23B343B60026176E /* SoraSDKManager.swift in Sources */,
 				9120C46123B342960026176E /* AppDelegate.swift in Sources */,
 				9120C48A23B343B60026176E /* PublisherConfigViewController.swift in Sources */,

--- a/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
@@ -16,7 +16,7 @@ class PublisherConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /**

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -55,7 +48,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, role, multistreamEnabledのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL,
+        var configuration = Configuration(url: Environment.url,
                                           channelId: channelId,
                                           role: role,
                                           multistreamEnabled: multistreamEnabled)

--- a/ScreenCastSample/ScreenCastSample/Environment.example.swift
+++ b/ScreenCastSample/ScreenCastSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}

--- a/SimulcastSample/README.md
+++ b/SimulcastSample/README.md
@@ -14,15 +14,19 @@
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``SimulcastSample/Environment.example.swift`` のファイル名を ``SimulcastSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp SimulcastSample/Environment.example.swift SimulcastSample/Environment.swift
+   ```
+
+３. ``SimulcastSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/SimulcastSample/SimulcastSample.xcodeproj/project.pbxproj
+++ b/SimulcastSample/SimulcastSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35DC8E9027A384BE000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E8F27A384BE000B0ED7 /* Environment.swift */; };
 		91483A3E264E5304009CA66E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91483A3D264E5304009CA66E /* AppDelegate.swift */; };
 		91483A40264E5304009CA66E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91483A3F264E5304009CA66E /* SceneDelegate.swift */; };
 		91483A45264E5304009CA66E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 91483A43264E5304009CA66E /* Main.storyboard */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		35DC8E8F27A384BE000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		91483A3A264E5304009CA66E /* SimulcastSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimulcastSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		91483A3D264E5304009CA66E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		91483A3F264E5304009CA66E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -71,6 +73,7 @@
 				91483A58264E5799009CA66E /* InfoPlist.strings */,
 				91483A3D264E5304009CA66E /* AppDelegate.swift */,
 				91483A3F264E5304009CA66E /* SceneDelegate.swift */,
+				35DC8E8F27A384BE000B0ED7 /* Environment.swift */,
 				91483A46264E5305009CA66E /* Assets.xcassets */,
 				91483A59264E5799009CA66E /* Classes */,
 				91483A48264E5305009CA66E /* LaunchScreen.storyboard */,
@@ -203,6 +206,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				91483A3E264E5304009CA66E /* AppDelegate.swift in Sources */,
+				35DC8E9027A384BE000B0ED7 /* Environment.swift in Sources */,
 				91483A5F264E5799009CA66E /* SoraSDKManager.swift in Sources */,
 				91483A60264E5799009CA66E /* VideoChatRoomViewController.swift in Sources */,
 				91483A40264E5304009CA66E /* SceneDelegate.swift in Sources */,

--- a/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
@@ -17,7 +17,7 @@ class ConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -56,7 +49,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL, channelId: channelId, role: .sendrecv,
+        var configuration = Configuration(url: Environment.url, channelId: channelId, role: .sendrecv,
                                           multistreamEnabled: true)
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec

--- a/SimulcastSample/SimulcastSample/Environment.example.swift
+++ b/SimulcastSample/SimulcastSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}

--- a/SpotlightSample/README.md
+++ b/SpotlightSample/README.md
@@ -14,15 +14,19 @@
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``SpotlightSample/Environment.example.swift`` のファイル名を ``SpotlightSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp SpotlightSample/Environment.example.swift SpotlightSample/Environment.swift
+   ```
+
+３. ``SpotlightSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/SpotlightSample/SpotlightSample.xcodeproj/project.pbxproj
+++ b/SpotlightSample/SpotlightSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		35DC8E9C27A38719000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E9B27A38719000B0ED7 /* Environment.swift */; };
 		911C1BDC2653AA3E007B1B59 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911C1BDB2653AA3E007B1B59 /* AppDelegate.swift */; };
 		911C1BDE2653AA3E007B1B59 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911C1BDD2653AA3E007B1B59 /* SceneDelegate.swift */; };
 		911C1BE32653AA3E007B1B59 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 911C1BE12653AA3E007B1B59 /* Main.storyboard */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		35DC8E9B27A38719000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		911C1BD82653AA3E007B1B59 /* SpotlightSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SpotlightSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		911C1BDB2653AA3E007B1B59 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		911C1BDD2653AA3E007B1B59 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				911C1BE92653AA3F007B1B59 /* Info.plist */,
 				911C1BDB2653AA3E007B1B59 /* AppDelegate.swift */,
 				911C1BDD2653AA3E007B1B59 /* SceneDelegate.swift */,
+				35DC8E9B27A38719000B0ED7 /* Environment.swift */,
 				911C1BE42653AA3F007B1B59 /* Assets.xcassets */,
 				911C1BE62653AA3F007B1B59 /* LaunchScreen.storyboard */,
 				911C1BE12653AA3E007B1B59 /* Main.storyboard */,
@@ -207,6 +210,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				91E3D012265B92F0003E19EC /* VideoChatRoomViewController.swift in Sources */,
+				35DC8E9C27A38719000B0ED7 /* Environment.swift in Sources */,
 				911C1BDC2653AA3E007B1B59 /* AppDelegate.swift in Sources */,
 				91E3D010265B92F0003E19EC /* ConfigViewController.swift in Sources */,
 				91E3D011265B92F0003E19EC /* SoraSDKManager.swift in Sources */,

--- a/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
@@ -23,7 +23,7 @@ class ConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -58,7 +51,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL, channelId: channelId, role: .sendrecv,
+        var configuration = Configuration(url: Environment.url, channelId: channelId, role: .sendrecv,
                                           multistreamEnabled: true)
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec

--- a/SpotlightSample/SpotlightSample/Environment.example.swift
+++ b/SpotlightSample/SpotlightSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}

--- a/VideoChatSample/README.md
+++ b/VideoChatSample/README.md
@@ -15,15 +15,19 @@
 
 ## ビルド方法
 
-このサンプルアプリは CocoaPods によって外部フレームワークの管理を行っているため、
-まず最初に以下のように `pod install` を実行する必要があります。
+1. CocoaPods でライブラリを取得します。
 
-```
-$ pod install
-```
+   ```
+   $ pod install
+   ```
 
-これにより、適切に外部フレームワークがセットアップされます。
-本サンプルアプリは、これだけで Xcode 上でビルドが可能な状態になります。
+2. (develop ブランチの場合) ``VideoChatSample/Environment.example.swift`` のファイル名を ``VideoChatSample/Environment.swift`` に変更し、接続情報を設定します。
+
+   ```
+   $ cp VideoChatSample/Environment.example.swift VideoChatSample/Environment.swift
+   ```
+
+３. ``VideoChatSample.xcworkspace`` を Xcode で開いてビルドします。
 
 ## サンプルアプリの使い方
 

--- a/VideoChatSample/VideoChatSample.xcodeproj/project.pbxproj
+++ b/VideoChatSample/VideoChatSample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0E55EF171F2FAC7300B5EFA8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E55EF151F2FAC7300B5EFA8 /* Main.storyboard */; };
 		0E55EF191F2FAC7300B5EFA8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0E55EF181F2FAC7300B5EFA8 /* Assets.xcassets */; };
 		0E55EF1C1F2FAC7300B5EFA8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E55EF1A1F2FAC7300B5EFA8 /* LaunchScreen.storyboard */; };
+		35DC8E9E27A389AE000B0ED7 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DC8E9D27A389AE000B0ED7 /* Environment.swift */; };
 		C57842AE1F41A18B001AF8AB /* ConfigViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57842AD1F41A18B001AF8AB /* ConfigViewController.swift */; };
 		C57842B01F41A196001AF8AB /* VideoChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57842AF1F41A196001AF8AB /* VideoChatRoomViewController.swift */; };
 		C57842B21F41A374001AF8AB /* SoraSDKManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57842B11F41A374001AF8AB /* SoraSDKManager.swift */; };
@@ -25,6 +26,7 @@
 		0E55EF181F2FAC7300B5EFA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0E55EF1B1F2FAC7300B5EFA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0E55EF1D1F2FAC7300B5EFA8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		35DC8E9D27A389AE000B0ED7 /* Environment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		C57842AD1F41A18B001AF8AB /* ConfigViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigViewController.swift; sourceTree = "<group>"; };
 		C57842AF1F41A196001AF8AB /* VideoChatRoomViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoChatRoomViewController.swift; sourceTree = "<group>"; };
 		C57842B11F41A374001AF8AB /* SoraSDKManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SoraSDKManager.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 			children = (
 				C57842AC1F41A134001AF8AB /* Classes */,
 				0E55EF111F2FAC7300B5EFA8 /* AppDelegate.swift */,
+				35DC8E9D27A389AE000B0ED7 /* Environment.swift */,
 				0E55EF181F2FAC7300B5EFA8 /* Assets.xcassets */,
 				0E55EF1A1F2FAC7300B5EFA8 /* LaunchScreen.storyboard */,
 				0E55EF151F2FAC7300B5EFA8 /* Main.storyboard */,
@@ -202,6 +205,7 @@
 				C57842B21F41A374001AF8AB /* SoraSDKManager.swift in Sources */,
 				C57842B01F41A196001AF8AB /* VideoChatRoomViewController.swift in Sources */,
 				0E55EF121F2FAC7300B5EFA8 /* AppDelegate.swift in Sources */,
+				35DC8E9E27A389AE000B0ED7 /* Environment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
@@ -23,7 +23,7 @@ class ConfigViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        channelIdTextField.text = "sora"
+        channelIdTextField.text = Environment.channelId
     }
 
     /**

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -13,13 +13,6 @@ class SoraSDKManager {
     static let shared = SoraSDKManager()
 
     /**
-     Sora SDKの接続先URLです。
-
-     お手元のSoraの接続先を指定してください。
-     */
-    private static let targetURL = URL(string: "wss://sora.example.com/signaling")!
-
-    /**
      現在接続中のSora SDKのMediaChannelです。
 
      殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
@@ -56,7 +49,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: SoraSDKManager.targetURL, channelId: channelId, role: role,
+        var configuration = Configuration(url: Environment.url, channelId: channelId, role: role,
                                           multistreamEnabled: multistreamEnabled)
 
         // 引数で指定された値を設定します。

--- a/VideoChatSample/VideoChatSample/Environment.example.swift
+++ b/VideoChatSample/VideoChatSample/Environment.example.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Environment {
+
+    // 接続するサーバーのシグナリング URL
+    static let url = URL(string: "wss://sora.example.com/signaling")!
+
+    // チャネル ID
+    static let channelId = "sora"
+
+}


### PR DESCRIPTION
sora-ios-sdk-quickstart で実施したローカル接続情報の外出しを sora-ios-sdk-samples でも対応しました。
VideoChatSamplesに対応をしたのですが、ファイルのディレクトリが VideoChatSample の直下で問題ないか、確認いただけないでしょうか。