### PR TITLE
urlCandidates を利用して接続を行うようにする

### DIFF
--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: DecoStreamingSample
       SCHEME: DecoStreamingSample
     steps:

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/realtime-streaming-sample.yml
+++ b/.github/workflows/realtime-streaming-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: RealTimeStreamingSample
       SCHEME: RealTimeStreamingSample
     steps:

--- a/.github/workflows/realtime-streaming-sample.yml
+++ b/.github/workflows/realtime-streaming-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: ScreenCastSample
       SCHEME: ScreenCastSample
     steps:

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: SimulcastSample
       SCHEME: SimulcastSample
     steps:

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: SpotlightSample
       SCHEME: SpotlightSample
     steps:

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -36,6 +36,9 @@ jobs:
         key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pods-
+    - name: use Podfile.dev on develop
+      if: github.ref != 'refs/heads/master'
+      run: rm Podfile && mv Podfile.dev Podfile           
     - name: Install Dependences
       run: |
         pod repo update

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_12.4.app
-      XCODE_SDK: iphoneos14.4
+      XCODE: /Applications/Xcode_13.2.1.app
+      XCODE_SDK: iphoneos15.2
       WORKSPACE: VideoChatSample
       SCHEME: VideoChatSample
     steps:

--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
@@ -61,7 +61,7 @@ class PublisherConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -71,7 +71,7 @@ class PublisherConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の配信画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -48,7 +48,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定は URL、チャネル ID、ロール、マルチストリームの可否です。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url,
+        var configuration = Configuration(urlCandidates: Environment.urls,
                                           channelId: channelId,
                                           role: role,
                                           multistreamEnabled: multistreamEnabled)
@@ -63,6 +63,7 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
         }
     }
 

--- a/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"

--- a/DecoStreamingSample/Podfile.dev
+++ b/DecoStreamingSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'DecoStreamingSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/RealTimeStreamingSample/Podfile.dev
+++ b/RealTimeStreamingSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'RealTimeStreamingSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherConfigViewController.swift
@@ -60,7 +60,8 @@ class PublisherConfigViewController: UITableViewController {
         // 突然暗黙的にconnectするのではなく、タップなどのユーザーのアクションに対して明示的にconnectを呼び出すことをおすすめします。
         SoraSDKManager.shared.connect(
             channelId: channelId,
-            role: .publisher,
+            role: .sendonly,
+            multistreamEnabled: false,
             videoCodec: videoCodec
         ) { [weak self] error in
             if let error = error {
@@ -68,7 +69,7 @@ class PublisherConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -78,7 +79,7 @@ class PublisherConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の配信画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherVideoViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/PublisherVideoViewController.swift
@@ -55,7 +55,7 @@ class PublisherVideoViewController: UIViewController {
 
         CameraVideoCapturer.flip(current) { error in
             if let error = error {
-                NSLog(error.localizedDescription)
+                NSLog("[sample] " + error.localizedDescription)
             }
         }
     }

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
@@ -36,6 +36,7 @@ class SoraSDKManager {
      */
     func connect(channelId: String,
                  role: Role,
+                 multistreamEnabled: Bool,
                  videoCodec: VideoCodec = .default,
                  completionHandler: ((Error?) -> Void)?)
     {
@@ -47,7 +48,10 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url, channelId: channelId, role: role)
+        var configuration = Configuration(urlCandidates: Environment.urls,
+                                          channelId: channelId,
+                                          role: role,
+                                          multistreamEnabled: multistreamEnabled)
 
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
@@ -58,6 +62,8 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
+
         }
     }
 

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SubscriberConfigViewController.swift
@@ -60,7 +60,8 @@ class SubscriberConfigViewController: UITableViewController {
         // 突然暗黙的にconnectするのではなく、タップなどのユーザーのアクションに対して明示的にconnectを呼び出すことをおすすめします。
         SoraSDKManager.shared.connect(
             channelId: channelId,
-            role: .subscriber,
+            role: .recvonly,
+            multistreamEnabled: false,
             videoCodec: videoCodec
         ) { [weak self] error in
             if let error = error {
@@ -68,7 +69,7 @@ class SubscriberConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -78,7 +79,7 @@ class SubscriberConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の視聴画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"

--- a/ScreenCastSample/Podfile.dev
+++ b/ScreenCastSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'ScreenCastSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -149,7 +149,7 @@ class GameViewController: UIViewController {
             if let error = error {
                 // エラーが発生して画面録画が開始できなかった場合は、Soraへの配信を停止する必要があります。
                 // 例えばユーザーが画面録画を許可しなかった場合などもこのエラーが発生します。
-                NSLog("Error while RPScreenRecorder.shared().startCapture: \(error)")
+                NSLog("[sample] Error while RPScreenRecorder.shared().startCapture: \(error)")
                 SoraSDKManager.shared.disconnect()
                 DispatchQueue.main.async {
                     self?.updateBarButtonItems()

--- a/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
@@ -61,7 +61,7 @@ class PublisherConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -71,7 +71,7 @@ class PublisherConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 接続が完了したので、ゲーム画面に戻ります。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -48,7 +48,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, role, multistreamEnabledのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url,
+        var configuration = Configuration(urlCandidates: Environment.urls,
                                           channelId: channelId,
                                           role: role,
                                           multistreamEnabled: multistreamEnabled)
@@ -62,6 +62,8 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
+
         }
     }
 

--- a/ScreenCastSample/ScreenCastSample/Environment.example.swift
+++ b/ScreenCastSample/ScreenCastSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"

--- a/SimulcastSample/Podfile.dev
+++ b/SimulcastSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'SimulcastSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
@@ -91,7 +91,7 @@ class ConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -101,7 +101,7 @@ class ConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の配信画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -49,7 +49,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url, channelId: channelId, role: .sendrecv,
+        var configuration = Configuration(urlCandidates: Environment.urls, channelId: channelId, role: .sendrecv,
                                           multistreamEnabled: true)
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
@@ -69,6 +69,8 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
+
         }
     }
 

--- a/SimulcastSample/SimulcastSample/Classes/VideoChatRoomViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/VideoChatRoomViewController.swift
@@ -33,13 +33,13 @@ class VideoChatRoomViewController: UIViewController {
         // 入室退室が発生したら都度動画の表示を更新しなければなりませんので、そのためのコールバックを設定します。
         if let mediaChannel = SoraSDKManager.shared.currentMediaChannel {
             mediaChannel.handlers.onAddStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onAddStream")
+                NSLog("[sample] mediaChannel.handlers.onAddStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
             }
             mediaChannel.handlers.onRemoveStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onRemoveStream")
+                NSLog("[sample] mediaChannel.handlers.onRemoveStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
@@ -239,7 +239,7 @@ extension VideoChatRoomViewController {
 
         CameraVideoCapturer.flip(current) { error in
             if let error = error {
-                NSLog(error.localizedDescription)
+                NSLog("[sample] " + error.localizedDescription)
             }
         }
     }

--- a/SimulcastSample/SimulcastSample/Environment.example.swift
+++ b/SimulcastSample/SimulcastSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"

--- a/SpotlightSample/Podfile.dev
+++ b/SpotlightSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'SpotlightSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
@@ -117,7 +117,7 @@ class ConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -127,7 +127,7 @@ class ConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の配信画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -51,7 +51,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url, channelId: channelId, role: .sendrecv,
+        var configuration = Configuration(urlCandidates: Environment.urls, channelId: channelId, role: .sendrecv,
                                           multistreamEnabled: true)
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
@@ -73,6 +73,7 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
         }
     }
 

--- a/SpotlightSample/SpotlightSample/Classes/VideoChatRoomViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/VideoChatRoomViewController.swift
@@ -33,13 +33,13 @@ class VideoChatRoomViewController: UIViewController {
         // 入室退室が発生したら都度動画の表示を更新しなければなりませんので、そのためのコールバックを設定します。
         if let mediaChannel = SoraSDKManager.shared.currentMediaChannel {
             mediaChannel.handlers.onAddStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onAddStream")
+                NSLog("[sample] mediaChannel.handlers.onAddStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
             }
             mediaChannel.handlers.onRemoveStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onRemoveStream")
+                NSLog("[sample] mediaChannel.handlers.onRemoveStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
@@ -239,7 +239,7 @@ extension VideoChatRoomViewController {
 
         CameraVideoCapturer.flip(current) { error in
             if let error = error {
-                NSLog(error.localizedDescription)
+                NSLog("[sample] " + error.localizedDescription)
             }
         }
     }

--- a/SpotlightSample/SpotlightSample/Environment.example.swift
+++ b/SpotlightSample/SpotlightSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"

--- a/VideoChatSample/Podfile.dev
+++ b/VideoChatSample/Podfile.dev
@@ -1,0 +1,12 @@
+source 'https://github.com/shiguredo/sora-ios-sdk-specs.git'
+source 'https://cdn.cocoapods.org/'
+
+platform :ios, '13.0'
+
+target 'VideoChatSample' do
+  use_frameworks!
+  pod 'Sora', :git => 'https://github.com/shiguredo/sora-ios-sdk.git', :branch => 'develop'
+
+  pod 'SwiftLint'
+  pod 'SwiftFormat/CLI'
+end

--- a/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
@@ -85,7 +85,7 @@ class ConfigViewController: UITableViewController {
                 // この場合は、エラー表示をユーザーに返すのが親切です。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、
                 // UI操作を行う際には必ずDispatchQueue.main.asyncを使用してメインスレッドでUI処理を呼び出すようにしてください。
-                NSLog("SoraSDKManager connection error: \(error)")
+                NSLog("[sample] SoraSDKManager connection error: \(error)")
                 DispatchQueue.main.async {
                     let alertController = UIAlertController(title: "接続に失敗しました",
                                                             message: error.localizedDescription,
@@ -95,7 +95,7 @@ class ConfigViewController: UITableViewController {
                 }
             } else {
                 // errorがnilの場合は、接続に成功しています。
-                NSLog("SoraSDKManager connected.")
+                NSLog("[sample] SoraSDKManager connected.")
 
                 // 次の配信画面に遷移します。
                 // なお、このコールバックはメインスレッド以外のスレッドから呼び出される可能性があるので、

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -49,7 +49,7 @@ class SoraSDKManager {
         // Configurationを生成して、接続設定を行います。
         // 必須となる設定はurl, channelId, roleのみです。
         // その他の設定にはデフォルト値が指定されていますが、ここで必要に応じて自由に調整することが可能です。
-        var configuration = Configuration(url: Environment.url, channelId: channelId, role: role,
+        var configuration = Configuration(urlCandidates: Environment.urls, channelId: channelId, role: role,
                                           multistreamEnabled: multistreamEnabled)
 
         // 引数で指定された値を設定します。
@@ -63,6 +63,7 @@ class SoraSDKManager {
             // 一方、接続に失敗した場合は、mediaChannelはnilとなり、errorが返されます。
             self?.currentMediaChannel = mediaChannel
             completionHandler?(error)
+            NSLog("[sample] mediaChannel.connectedUrl: \(String(describing: mediaChannel?.connectedUrl))")
         }
     }
 

--- a/VideoChatSample/VideoChatSample/Classes/VideoChatRoomViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/VideoChatRoomViewController.swift
@@ -27,13 +27,13 @@ class VideoChatRoomViewController: UIViewController {
         // 入室退室が発生したら都度動画の表示を更新しなければなりませんので、そのためのコールバックを設定します。
         if let mediaChannel = SoraSDKManager.shared.currentMediaChannel {
             mediaChannel.handlers.onAddStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onAddStream")
+                NSLog("[sample] mediaChannel.handlers.onAddStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
             }
             mediaChannel.handlers.onRemoveStream = { [weak self] _ in
-                NSLog("mediaChannel.handlers.onRemoveStream")
+                NSLog("[sample] mediaChannel.handlers.onRemoveStream")
                 DispatchQueue.main.async {
                     self?.handleUpdateStreams()
                 }
@@ -231,7 +231,7 @@ extension VideoChatRoomViewController {
 
         CameraVideoCapturer.flip(current) { error in
             if let error = error {
-                NSLog(error.localizedDescription)
+                NSLog("[sample] " + error.localizedDescription)
             }
         }
     }

--- a/VideoChatSample/VideoChatSample/Environment.example.swift
+++ b/VideoChatSample/VideoChatSample/Environment.example.swift
@@ -3,7 +3,8 @@ import Foundation
 enum Environment {
 
     // 接続するサーバーのシグナリング URL
-    static let url = URL(string: "wss://sora.example.com/signaling")!
+    // 配列で複数の URL を指定することが可能です
+    static let urls = [URL(string: "wss://sora.example.com/signaling")!]
 
     // チャネル ID
     static let channelId = "sora"


### PR DESCRIPTION
追加で以下の対応も実施しています
・deprecated となった要素、メソッドについての対応
・" [samples]" をログの先頭に追加

GitHub Actions でエラーとなったため、 Xcode のバージョンアップ、master ブランチ以外は sora-ios-sdk の develop ブランチを使ってビルドチェックを行うよう修正をしています。