### PR TITLE
Environment.example.swift に signalingConnectMetadata を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [UPDATE] Github Actions でのビルド処理で利用する Podfile を Podfile.dev からPodfile に変更する 
     - @miosakuma
+- [UPDATE] Environment.example.swift に signalingConnectMetadata を追加する 
+    - @miosakuma
 - [ADD] DataChannelSample の追加する
     - @szktty
 - [FIX] 接続ボタンを連打された際に複数の接続が作成される不具合を修正する

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -56,6 +56,7 @@ class SoraSDKManager {
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
         configuration.cameraSettings.isEnabled = false
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in

--- a/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Classes/SoraSDKManager.swift
@@ -55,6 +55,7 @@ class SoraSDKManager {
 
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in

--- a/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
+++ b/RealTimeStreamingSample/RealTimeStreamingSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -56,6 +56,8 @@ class SoraSDKManager {
         // 引数で指定された値を設定します。
         configuration.videoCodec = videoCodec
         configuration.cameraSettings.isEnabled = false
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
+
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in
             // 接続に成功した場合は、mediaChannelに値が返され、errorがnilになります。

--- a/ScreenCastSample/ScreenCastSample/Environment.example.swift
+++ b/ScreenCastSample/ScreenCastSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -56,6 +56,7 @@ class SoraSDKManager {
         configuration.simulcastRid = simulcastRid
         configuration.dataChannelSignaling = dataChannelSignaling
         configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // サイマルキャストを有効にします。
         configuration.simulcastEnabled = true

--- a/SimulcastSample/SimulcastSample/Environment.example.swift
+++ b/SimulcastSample/SimulcastSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -60,6 +60,7 @@ class SoraSDKManager {
         configuration.spotlightNumber = spotlightNumber
         configuration.dataChannelSignaling = dataChannelSignaling
         configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // スポットライトを有効にします。
         configuration.spotlightEnabled = .enabled

--- a/SpotlightSample/SpotlightSample/Environment.example.swift
+++ b/SpotlightSample/SpotlightSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -57,6 +57,7 @@ class SoraSDKManager {
         configuration.videoCodec = videoCodec
         configuration.dataChannelSignaling = dataChannelSignaling
         configuration.ignoreDisconnectWebSocket = ignoreDisconnectWebSocket
+        configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
 
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in

--- a/VideoChatSample/VideoChatSample/Environment.example.swift
+++ b/VideoChatSample/VideoChatSample/Environment.example.swift
@@ -7,4 +7,7 @@ enum Environment {
 
     // チャネル ID
     static let channelId = "sora"
+
+    // type: connect に含めるメタデータ
+    static let signalingConnectMetadata: Encodable? = nil
 }


### PR DESCRIPTION
Environment.example.swift に signalingConnectMetadata を追加しました。
すでに追加済みの DataChannelSample の内容を横展開しています。