### PR TITLE
[ScreenCastSample] 切断時の処理にキャプチャー停止を追加する

### DIFF
--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -163,11 +163,14 @@ class GameViewController: UIViewController {
      いずれの場合も含めます。
      */
     private func handleDisconnect() {
-        // 画面録画を停止して、配信を切断し、ボタンの状態を更新します。
-        RPScreenRecorder.shared().stopCapture { _ in
-            // エラー時処理を行う必要が無いので、無視します。
-            NSLog("[sample] stop Capture")
+        // 画面録画中であれば録画を停止して、配信を切断し、ボタンの状態を更新します。
+        if RPScreenRecorder.shared().isRecording {
+            RPScreenRecorder.shared().stopCapture { _ in
+                // エラー時処理を行う必要が無いので、無視します。
+                NSLog("[sample] stop Capture")
+            }
         }
+
         // 明示的に配信をストップしてから、画面を閉じるようにしています。
         SoraSDKManager.shared.disconnect()
         DispatchQueue.main.async { [weak self] in

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -101,12 +101,7 @@ class GameViewController: UIViewController {
     func onPauseButton(_ sender: UIBarButtonItem) {
         let isConnected = (SoraSDKManager.shared.currentMediaChannel != nil)
         if isConnected {
-            // 画面録画を停止して、配信を切断し、ボタンの状態を更新します。
-            RPScreenRecorder.shared().stopCapture { _ in
-                // エラー時処理を行う必要が無いので、無視します。
-            }
-            SoraSDKManager.shared.disconnect()
-            updateBarButtonItems()
+            handleDisconnect()
         } else {
             // 配信されていないので何もしなくて良いです。ボタンの状態だけ更新します。
             updateBarButtonItems()
@@ -168,6 +163,11 @@ class GameViewController: UIViewController {
      いずれの場合も含めます。
      */
     private func handleDisconnect() {
+        // 画面録画を停止して、配信を切断し、ボタンの状態を更新します。
+        RPScreenRecorder.shared().stopCapture { _ in
+            // エラー時処理を行う必要が無いので、無視します。
+            NSLog("[sample] stop Capture")
+        }
         // 明示的に配信をストップしてから、画面を閉じるようにしています。
         SoraSDKManager.shared.disconnect()
         DispatchQueue.main.async { [weak self] in

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -167,7 +167,6 @@ class GameViewController: UIViewController {
         if RPScreenRecorder.shared().isRecording {
             RPScreenRecorder.shared().stopCapture { _ in
                 // エラー時処理を行う必要が無いので、無視します。
-                NSLog("[sample] stop Capture")
             }
         }
 


### PR DESCRIPTION
スクリーンキャストサンプルで Sora から切断された後の再接続操作で映像が送信されない問題があったので修正をしたいと考えています。

現在は 2 つの問題があります。

1. Sora から切断された後の再接続操作で映像が送信されなくなる。
切断時にキャプチャー停止をしていなかったために、再接続操作のキャプチャー開始時に既にキャプチャーセッションがあるためエラーとなっていた。
切断時に stopCapture() を呼ぶことで解消している

2. onPauseButton からの切断処理を契機に mediaChannel.handlers.onDisconnect が呼ばれるため、結果切断処理が2回連続で実行される
結果、stopCapture() で停止対象のキャプチャーが存在しないエラーが発生しますが、エラーは無視しているため特に動作的な問題は発生していません。

"2." についてよい解決方法があるか、不要な処理が実行されてしまう状況をよしとするべきなのか相談させてください。