### PR TITLE
Feature/screencastsample capture error

### DIFF
--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -163,17 +163,20 @@ class GameViewController: UIViewController {
      いずれの場合も含めます。
      */
     private func handleDisconnect() {
-        // 明示的に配信をストップしてから、画面を閉じるようにしています。
-        SoraSDKManager.shared.disconnect()
-        DispatchQueue.main.async { [weak self] in
-            self?.updateBarButtonItems()
-        }
+        // 明示的に配信を停止してからボタンの状態を更新し、画面を閉じるようにしています。
 
-        // 画面録画中であれば録画を停止して、配信を切断し、ボタンの状態を更新します。
-        // 切断する前に録画を停止するとデバイスが正しく終了されない場合があるので、切断後に録画を停止するようにしています。
+        // 画面録画中であれば先に録画を停止します。
         if RPScreenRecorder.shared().isRecording {
             RPScreenRecorder.shared().stopCapture { _ in
-                // エラー時処理を行う必要が無いので、無視します。
+                SoraSDKManager.shared.disconnect()
+                DispatchQueue.main.async { [weak self] in
+                    self?.updateBarButtonItems()
+                }
+            }
+        } else {
+            SoraSDKManager.shared.disconnect()
+            DispatchQueue.main.async { [weak self] in
+                self?.updateBarButtonItems()
             }
         }
     }

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -163,17 +163,18 @@ class GameViewController: UIViewController {
      いずれの場合も含めます。
      */
     private func handleDisconnect() {
-        // 画面録画中であれば録画を停止して、配信を切断し、ボタンの状態を更新します。
-        if RPScreenRecorder.shared().isRecording {
-            RPScreenRecorder.shared().stopCapture { _ in
-                // エラー時処理を行う必要が無いので、無視します。
-            }
-        }
-
         // 明示的に配信をストップしてから、画面を閉じるようにしています。
         SoraSDKManager.shared.disconnect()
         DispatchQueue.main.async { [weak self] in
             self?.updateBarButtonItems()
+        }
+
+        // 画面録画中であれば録画を停止して、配信を切断し、ボタンの状態を更新します。
+        // 切断する前に録画を停止するとデバイスが正しく終了されない場合があるので、切断後に録画を停止するようにしています。
+        if RPScreenRecorder.shared().isRecording {
+            RPScreenRecorder.shared().stopCapture { _ in
+                // エラー時処理を行う必要が無いので、無視します。
+            }
         }
     }
 

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -57,6 +57,7 @@ class SoraSDKManager {
         configuration.videoCodec = videoCodec
         configuration.cameraSettings.isEnabled = false
         configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
+        configuration.audioEnabled = false
 
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -57,7 +57,6 @@ class SoraSDKManager {
         configuration.videoCodec = videoCodec
         configuration.cameraSettings.isEnabled = false
         configuration.signalingConnectMetadata = Environment.signalingConnectMetadata
-        configuration.audioEnabled = false
 
         // Soraに接続を試みます。
         _ = Sora.shared.connect(configuration: configuration) { [weak self] mediaChannel, error in


### PR DESCRIPTION
ScreenCastSample において、次の手順で発生する事象を修正します。

1. 接続し、映像を送信する
2. Sora 側から切断する (API の DisconnectChannel を送信したり、 Sora を再起動する)
3. 再度接続を試みると接続に失敗する

## 変更点

これまでは画面収録停止後に切断していましたが、逆にして切断後に画面収録停止します。デバイスの終了処理の順序が問題だったようです。