### PR TITLE
[CI] CI ビルド環境の最新化 (macOS 12, Xcode 13.4.1)

### DIFF
--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: DataChannelSample
       SCHEME: DataChannelSample
     steps:

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: DecoStreamingSample
       SCHEME: DecoStreamingSample
     steps:

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: ScreenCastSample
       SCHEME: ScreenCastSample
     steps:

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: SimulcastSample
       SCHEME: SimulcastSample
     steps:

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: SpotlightSample
       SCHEME: SpotlightSample
     steps:

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
       XCODE: /Applications/Xcode_13.4.1.app
       XCODE_SDK: iphoneos15.5

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macOS-latest
     env:
-      XCODE: /Applications/Xcode_13.2.1.app
-      XCODE_SDK: iphoneos15.2
+      XCODE: /Applications/Xcode_13.4.1.app
+      XCODE_SDK: iphoneos15.5
       WORKSPACE: VideoChatSample
       SCHEME: VideoChatSample
     steps:


### PR DESCRIPTION
daily のビルドが 2022/8/27 から失敗していたので、macOS, Xcode のバージョンをビルドが成功する手元の環境に合わせました。

macOS-latest (macOS 11.6) では Xcode 13.2.1 のままであったため、明示的に macos-12 を使用しています。
Xcode のバージョンの指定も明示的に指定しているので OS のバージョンも指定でよいと考えています。

問題なければ sora-ios-sdk, sora-ios-sdk-quickstart にも反映していきます。 