### PR TITLE
各サンプルの libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [UPDATE] 各サンプルの libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
+  - libwebrtc のログを INFO レベルで出力するようにする
+  - @zztkm
+
 ## sora-ios-sdk-2024.2.0
 
 - [UPDATE] Github Actions を actions/cache@v4 にあげる

--- a/DataChannelSample/DataChannelSample/SoraSDKManager.swift
+++ b/DataChannelSample/DataChannelSample/SoraSDKManager.swift
@@ -32,6 +32,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -26,6 +26,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -26,6 +26,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -26,6 +26,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -26,6 +26,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -26,6 +26,7 @@ class SoraSDKManager {
         // SDK のログを表示します。
         // 送受信されるシグナリングの内容や接続エラーを確認できます。
         Logger.shared.level = .debug
+        Sora.setWebRTCLogLevel(.info)
     }
 
     /**


### PR DESCRIPTION
変更内容

- [UPDATE] 各サンプルの libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
  - libwebrtc のログを INFO レベルで出力するようにする

---

This pull request primarily involves changes to the logging level of the libwebrtc library in various samples of the Sora SDK. The logging level has been changed from `RTCLoggingSeverityNone` to `RTCLoggingSeverityInfo` to allow for INFO level output. This change has been reflected in the `CHANGES.md` file and in the `SoraSDKManager` class across multiple sample projects.

Here are the most important changes:

Changes to `CHANGES.md`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R17): Updated the development logs to reflect the change in the libwebrtc logging level from `RTCLoggingSeverityNone` to `RTCLoggingSeverityInfo`.

Changes to `SoraSDKManager` class in various sample projects:

* [`DataChannelSample/DataChannelSample/SoraSDKManager.swift`](diffhunk://#diff-555dfd3ba4e7865530726c47c653b6bcb7cf0817c15051fbfad12c0a102275bcR35): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.
* [`DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift`](diffhunk://#diff-e323962e973e33c4e1d77aa029aaab58d890e0d28aabc526ca2adac88c4e67c4R29): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.
* [`ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift`](diffhunk://#diff-79ca805f3d51004a82a41def03989a83a2f6847563ef561b0a1d50c6cf649a07R29): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.
* [`SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift`](diffhunk://#diff-21397ddf79ca1cd60eef85e08a54084d0d700e1564e5a534bb47b4ee7f481c0aR29): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.
* [`SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift`](diffhunk://#diff-41864306be26e42d81b612d2275fb2a66833f0cec3616b5e60e1878688883327R29): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.
* [`VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift`](diffhunk://#diff-159f0721b0d730f531c9072feca72671f8ec55521c200fb488adace747d4980aR29): Updated the `Sora.setWebRTCLogLevel` method to use `.info` level.