### PR TITLE
Github Actions の Xcode を 15.4 にあげる

### DIFF
--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: DataChannelSample
       SCHEME: DataChannelSample
     steps:

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: DecoStreamingSample
       SCHEME: DecoStreamingSample
     steps:

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: ScreenCastSample
       SCHEME: ScreenCastSample
     steps:

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: SimulcastSample
       SCHEME: SimulcastSample
     steps:

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: SpotlightSample
       SCHEME: SpotlightSample
     steps:

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: macos-14
     env:
-      XCODE: /Applications/Xcode_15.2.app
-      XCODE_SDK: iphoneos17.2
+      XCODE: /Applications/Xcode_15.4.app
+      XCODE_SDK: iphoneos17.5
       WORKSPACE: VideoChatSample
       SCHEME: VideoChatSample
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,10 @@
 - [UPDATE] 各サンプルの libwebrtc のログレベルを RTCLoggingSeverityNone から RTCLoggingSeverityInfo にする
   - libwebrtc のログを INFO レベルで出力するようにする
   - @zztkm
-
+- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
+  - 合わせて iOS の SDK を iphoneos17.5 にあげる
+  - @miosakuma
+  
 ## sora-ios-sdk-2024.2.0
 
 - [UPDATE] Github Actions を actions/cache@v4 にあげる


### PR DESCRIPTION
- [UPDATE] GitHub Actions の Xcode のバージョンを 15.4 にあげる
  - 合わせて iOS の SDK を iphoneos17.5 にあげる

---

This pull request updates the Xcode and iOS SDK versions used in GitHub Actions workflows for multiple sample projects. The changes ensure compatibility with the latest development tools and SDKs.

### GitHub Actions Workflow Updates:
* [`.github/workflows/data-channel-sample.yml`](diffhunk://#diff-786a1681d78fea3bcd23ea872b930cec2437692efee0b2510b8415f786cfb614L20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.
* [`.github/workflows/deco-streaming-sample.yml`](diffhunk://#diff-e3882bb6d4c27f97c42cb8a14159c9d9a614c23fd5ba5d840fad12e9fd45f20dL20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.
* [`.github/workflows/screencast-sample.yml`](diffhunk://#diff-794d3f8130943a9230ba2669111c92149ffdf64c8dfae4c7d8900ca62cea7424L20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.
* [`.github/workflows/simulcast-sample.yml`](diffhunk://#diff-60a13ce494fa185c09d33d4dfd936553c8f7881f0b111775d7653ec8924632dfL20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.
* [`.github/workflows/spotlight-sample.yml`](diffhunk://#diff-3d8340b5d1a88fcf95803b59aff7d72d0527900a483ea7ceb91215503c997a61L20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.
* [`.github/workflows/video-chat-sample.yml`](diffhunk://#diff-3b4330d4f49ff4a6d991d7d70bfd84defb72aefc2797c20265968c242a26b7d9L20-R21): Updated Xcode version to 15.4 and iOS SDK to iphoneos17.5.

### Documentation Update:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R17-R19): Added an entry to document the updates to Xcode and iOS SDK versions in GitHub Actions workflows.