### PR TITLE
映像コーデックタイプに none を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,8 +23,7 @@
   - @zztkm
 - [ADD] 映像コーデックタイプに H.265 を追加する
   - @zztkm
-- [ADD] 映像コーデックタイプに none を追加する
-  - `SimulcastSample` と `SpotlightSample` に追加
+- [ADD] none 項目がなかった `SimulcastSample` と `SpotlightSample` に none を追加
   - @zztkm
 
 ## sora-ios-sdk-2024.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@
   - @zztkm
 - [ADD] 映像コーデックタイプに H.265 を追加する
   - @zztkm
+- [ADD] 映像コーデックタイプに none を追加する
+  - `SimulcastSample` と `SpotlightSample` に追加
+  - @zztkm
 
 ## sora-ios-sdk-2024.3.0
 

--- a/SimulcastSample/SimulcastSample/Base.lproj/Main.storyboard
+++ b/SimulcastSample/SimulcastSample/Base.lproj/Main.storyboard
@@ -76,6 +76,7 @@
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="jHA-3S-8CN">
                                                     <rect key="frame" x="20" y="6.5" width="335" height="32"/>
                                                     <segments>
+                                                        <segment title="none"/>
                                                         <segment title="VP8"/>
                                                         <segment title="VP9"/>
                                                         <segment title="AV1"/>

--- a/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
@@ -55,11 +55,12 @@ class ConfigViewController: UITableViewController {
         // ユーザーが選択した設定をUIコントロールから取得します。
         let videoCodec: VideoCodec
         switch videoCodecSegmentedControl.selectedSegmentIndex {
-        case 0: videoCodec = .vp8
-        case 1: videoCodec = .vp9
-        case 2: videoCodec = .av1
-        case 3: videoCodec = .h264
-        case 4: videoCodec = .h265
+        case 0: videoCodec = .default
+        case 1: videoCodec = .vp8
+        case 2: videoCodec = .vp9
+        case 3: videoCodec = .av1
+        case 4: videoCodec = .h264
+        case 5: videoCodec = .h265
         default: fatalError()
         }
 

--- a/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
+++ b/SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard
@@ -76,6 +76,7 @@
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="jHA-3S-8CN">
                                                     <rect key="frame" x="20" y="6.5" width="335" height="32"/>
                                                     <segments>
+                                                        <segment title="none"/>
                                                         <segment title="VP8"/>
                                                         <segment title="VP9"/>
                                                         <segment title="AV1"/>

--- a/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
@@ -64,11 +64,12 @@ class ConfigViewController: UITableViewController {
         // ユーザーが選択した設定をUIコントロールから取得します。
         let videoCodec: VideoCodec
         switch videoCodecSegmentedControl.selectedSegmentIndex {
-        case 0: videoCodec = .vp8
-        case 1: videoCodec = .vp9
-        case 2: videoCodec = .av1
-        case 3: videoCodec = .h264
-        case 4: videoCodec = .h265
+        case 0: videoCodec = .default
+        case 1: videoCodec = .vp8
+        case 2: videoCodec = .vp9
+        case 3: videoCodec = .av1
+        case 4: videoCodec = .h264
+        case 5: videoCodec = .h265
         default: fatalError()
         }
 


### PR DESCRIPTION
- [ADD] 映像コーデックタイプに none を追加する
  - `SimulcastSample` と `SpotlightSample` に追加

---

This pull request includes changes to add a new video codec type, "none," to the `SimulcastSample` and `SpotlightSample` projects. The most important changes are the addition of the new codec type to the UI and the corresponding handling in the code.

### Addition of "none" video codec type:

* [`SimulcastSample/SimulcastSample/Base.lproj/Main.storyboard`](diffhunk://#diff-0ccfe8c7ef02bf418a07a2525674832c91bde1e97f82ef4100187d8156033016R79): Added a new segment titled "none" to the segmented control for video codec selection.
* [`SpotlightSample/SpotlightSample/Base.lproj/Main.storyboard`](diffhunk://#diff-1f65300790d7ee70810026e81ea59771c98b079bd543fb78ebff0a047dd69652R79): Added a new segment titled "none" to the segmented control for video codec selection.

### Handling of the new codec type in code:

* [`SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift`](diffhunk://#diff-f3df9fbb0f4bf2634b4f92235caa42209d03930d6890451cc635275b9a78010cL58-R63): Updated the `switch` statement in the `ConfigViewController` class to handle the new "none" video codec type.
* [`SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift`](diffhunk://#diff-ceca3a8335e8b9ec0f76e7beb29bbff861a0d882627e7787f9d9e10fc8227368L67-R72): Updated the `switch` statement in the `ConfigViewController` class to handle the new "none" video codec type.

### Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R26-R28): Added an entry to document the addition of the "none" video codec type.