### PR TITLE
GitHub Actions 環境をアップデートする

### DIFF
--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: DataChannelSample
       SCHEME: DataChannelSample
     steps:

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: DecoStreamingSample
       SCHEME: DecoStreamingSample
     steps:

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: ScreenCastSample
       SCHEME: ScreenCastSample
     steps:

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: SimulcastSample
       SCHEME: SimulcastSample
     steps:

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: SpotlightSample
       SCHEME: SpotlightSample
     steps:

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      XCODE: /Applications/Xcode_15.4.app
-      XCODE_SDK: iphoneos17.5
+      XCODE: /Applications/Xcode_16.2.app
+      XCODE_SDK: iphoneos18.2
       WORKSPACE: VideoChatSample
       SCHEME: VideoChatSample
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@
 
 - [UPDATE] GitHub Actions の定期実行をやめる
   - @zztkm
+- [UPDATE] GitHub Actions のビルド環境を更新する
+  - runner を macos-15 に変更
+  - Xcode の version を 16.2 に変更
+  - SDK を iOS 18.2 に変更
+  - @zztkm
 
 ## sora-ios-sdk-2025.1.1
 


### PR DESCRIPTION
- [UPDATE] GitHub Actions のビルド環境を更新する
  - runner を macos-15 に変更
  - Xcode の version を 16.2 に変更
  - SDK を iOS 18.2 に変更

---

This pull request updates the GitHub Actions workflows to use a newer macOS version and Xcode environment. The changes affect multiple workflow files and also update the `CHANGES.md` file to reflect these updates.

Updates to GitHub Actions workflows:

* [`.github/workflows/data-channel-sample.yml`](diffhunk://#diff-786a1681d78fea3bcd23ea872b930cec2437692efee0b2510b8415f786cfb614L16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.
* [`.github/workflows/deco-streaming-sample.yml`](diffhunk://#diff-e3882bb6d4c27f97c42cb8a14159c9d9a614c23fd5ba5d840fad12e9fd45f20dL16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.
* [`.github/workflows/screencast-sample.yml`](diffhunk://#diff-794d3f8130943a9230ba2669111c92149ffdf64c8dfae4c7d8900ca62cea7424L16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.
* [`.github/workflows/simulcast-sample.yml`](diffhunk://#diff-60a13ce494fa185c09d33d4dfd936553c8f7881f0b111775d7653ec8924632dfL16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.
* [`.github/workflows/spotlight-sample.yml`](diffhunk://#diff-3d8340b5d1a88fcf95803b59aff7d72d0527900a483ea7ceb91215503c997a61L16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.
* [`.github/workflows/video-chat-sample.yml`](diffhunk://#diff-3b4330d4f49ff4a6d991d7d70bfd84defb72aefc2797c20265968c242a26b7d9L16-R19): Updated `runs-on` to `macos-15`, `XCODE` to `16.2`, and `XCODE_SDK` to `iphoneos18.2`.

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R16-R20): Added an update entry for the changes in GitHub Actions build environment.