### PR TITLE
フォーマッター実行用の Makefile を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,9 @@
   - Xcode の version を 16.2 に変更
   - SDK を iOS 18.2 に変更
   - @zztkm
+- [ADD] swift-format 実行用の Makefile を追加する
+  - lint-format.sh で一括実行していたコマンドを個別に実行できるようにした
+  - @zztkm
 
 ## sora-ios-sdk-2025.1.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: fmt fmt-lint
+
+# swift-format
+fmt:
+	swift format --in-place --recursive .
+
+# swift-format lint
+fmt-lint:
+	swift format lint --strict --parallel --recursive .
+
+# すべてを実行
+all: fmt-lint fmt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: fmt fmt-lint
 
+# すべてを実行
+all: fmt fmt-lint
+
 # swift-format
 fmt:
 	swift format --in-place --recursive .
@@ -8,5 +11,3 @@ fmt:
 fmt-lint:
 	swift format lint --strict --parallel --recursive .
 
-# すべてを実行
-all: fmt-lint fmt


### PR DESCRIPTION
- [ADD] swift-format 実行用の Makefile を追加する
  - lint-format.sh で一括実行していたコマンドを個別に実行できるようにした

---

This pull request includes changes to the `CHANGES.md` file and the addition of a new `Makefile` to improve code formatting and linting processes. The most important changes include adding a Makefile for running `swift-format` commands and updating the `CHANGES.md` file to reflect this addition.

Improvements to code formatting and linting:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R12): Added targets `fmt` and `fmt-lint` to run `swift-format` and `swift-format lint` commands, respectively. Also added a target `all` to execute both commands.
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R28-R30): Updated the changelog to include the addition of the `swift-format` Makefile and detailed the changes made to the linting process.