### PR TITLE
swift-format lint の警告を修正する

### DIFF
--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=DataChannelSample

--- a/.github/workflows/data-channel-sample.yml
+++ b/.github/workflows/data-channel-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/.github/workflows/deco-streaming-sample.yml
+++ b/.github/workflows/deco-streaming-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=DecoStreamingSample

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/.github/workflows/screencast-sample.yml
+++ b/.github/workflows/screencast-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=ScreenCastSample

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=SimulcastSample

--- a/.github/workflows/simulcast-sample.yml
+++ b/.github/workflows/simulcast-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/.github/workflows/spotlight-sample.yml
+++ b/.github/workflows/spotlight-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=SpotlightSample

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -52,4 +52,4 @@ jobs:
     - name: Check uncommitted unformatted code
       run: |
         cp ../Makefile .
-        make fmt-lint
+        make fmt-lint TARGET_PATH=VideoChatSample

--- a/.github/workflows/video-chat-sample.yml
+++ b/.github/workflows/video-chat-sample.yml
@@ -49,8 +49,7 @@ jobs:
             CODE_SIGN_IDENTITY= \
             PROVISIONING_PROFILE= \
             ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS=NO
-    # TODO(zztkm): fmt-lint で出力される警告を修正するタイミングでコメントアウトを外す
-    # - name: Check uncommitted unformatted code
-    #   run: |
-    #     cp ../Makefile .
-    #     make fmt-lint
+    - name: Check uncommitted unformatted code
+      run: |
+        cp ../Makefile .
+        make fmt-lint

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
   - @zztkm
 - [ADD] swift-format 実行用の Makefile を追加する
   - lint-format.sh で一括実行していたコマンドを個別に実行できるようにした
+  - デフォルトでは make コマンドを実行したディレクトリから再帰的に .swift ファイルを探すが、`TARGET_PATH` 変数を与えることで特定のディレクトリ以下の .swift ファイルを対象にすることも可能
   - @zztkm
 
 ## sora-ios-sdk-2025.1.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,8 @@
   - @zztkm
 - [UPDATE] フォーマッターとリンターの実行を Makefile と Xcode に分割したため、不要になった lint-format.sh を削除
   - @zztkm
+- [UPDATE] swift-format lint で出力される警告を修正
+  - @zztkm
 - [UPDATE] GitHub Actions の定期実行をやめる
   - @zztkm
 - [UPDATE] GitHub Actions のビルド環境を更新する

--- a/DataChannelSample/DataChannelSample/ConfigViewController.swift
+++ b/DataChannelSample/DataChannelSample/ConfigViewController.swift
@@ -68,18 +68,14 @@ class ConfigViewController: UITableViewController {
   /// 接続試行中かどうかを表します。
   var isConnecting = false
 
-  /**
-     画面起動時の処理を記述します。
-     */
+  /// 画面起動時の処理を記述します。
   override func viewDidLoad() {
     super.viewDidLoad()
 
     channelIdTextField.text = Environment.channelId
   }
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)
@@ -256,28 +252,22 @@ class ConfigViewController: UITableViewController {
     }
   }
 
-  /**
-     配信画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onUnwindToConfig(_ segue: UIStoryboardSegue) {
     // 前の画面から戻ってきても、特に処理は何も行いません。
   }
 
-  /**
-     テーブルビューのタップ時に呼ばれます。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// テーブルビューのタップ時に呼ばれます。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onTapTableView(_ sender: UITapGestureRecognizer) {
     // テキストフィールドの入力中であれば、表示されているキーボードを閉じます。
     channelIdTextField.endEditing(true)
     dataChannelProtocolTextField.endEditing(true)
   }
 
-  /**
-     テキストフィールドの入力終了時に呼ばれます。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// テキストフィールドの入力終了時に呼ばれます。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onTextFieldDidEnd(_ sender: Any?) {
     // 表示されているキーボードを閉じます。
     channelIdTextField.endEditing(true)

--- a/DataChannelSample/DataChannelSample/SoraSDKManager.swift
+++ b/DataChannelSample/DataChannelSample/SoraSDKManager.swift
@@ -5,27 +5,19 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  ///
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     DataChannel メッセージでランダムなバイナリを送信するかどうかを指定します。
-     VideoChatViewController から参照されます。
-     */
+  /// DataChannel メッセージでランダムなバイナリを送信するかどうかを指定します。
+  /// VideoChatViewController から参照されます。
   var dataChannelRandomBinary: Bool = false
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -33,12 +25,10 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  ///
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     with configuration: Configuration,
     completionHandler: ((Error?) -> Void)?
@@ -56,11 +46,9 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  ///
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/DataChannelSample/DataChannelSample/VideoChatRoomViewController.swift
+++ b/DataChannelSample/DataChannelSample/VideoChatRoomViewController.swift
@@ -21,30 +21,22 @@ class VideoChatRoomViewController: UIViewController {
   /// 送受信したチャットメッセージの履歴を表示するコントロールです。
   @IBOutlet weak var historyTableView: UITableView!
 
-  /**
-     タップでメッセージ入力キーボードを閉じるためのジェスチャー認識器です。
-      */
+  /// タップでメッセージ入力キーボードを閉じるためのジェスチャー認識器です。
   @IBOutlet weak var tapGestureRecognizer: UITapGestureRecognizer!
 
-  /** ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。
   private var downstreamVideoViews: [VideoView] = []
 
-  /** ビデオチャットの、配信者自身の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者自身の映像を表示するためのViewです。
   private var upstreamVideoView: VideoView?
 
-  /**
-        チャットメッセージの履歴です。
-     */
+  /// チャットメッセージの履歴です。
   var history: [ChatMessage] = []
 
-  /**
-     配信画面で選択されたラベルです。このラベルでメッセージを送信します。
-     */
+  /// 配信画面で選択されたラベルです。このラベルでメッセージを送信します。
   var selectedLabel: String?
 
-  /**
-     送信するバイナリメッセージです。ランダムなバイナリを送信するように指定した場合に使います。
-     */
+  /// 送信するバイナリメッセージです。ランダムなバイナリを送信するように指定した場合に使います。
   var binaryToSend: Data?
 
   override func viewDidLoad() {
@@ -296,9 +288,7 @@ class VideoChatRoomViewController: UIViewController {
 // MARK: - Sora SDKのイベントハンドリング
 
 extension VideoChatRoomViewController {
-  /**
-     接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
-     */
+  /// 接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
   private func handleUpdateStreams() {
     // まずはmediaPublisherのmediaStreamを取得します。
     guard (SoraSDKManager.shared.currentMediaChannel?.streams) != nil else {
@@ -351,11 +341,9 @@ extension VideoChatRoomViewController {
     layoutVideoViews(for: memberListView.bounds.size)
   }
 
-  /**
-     接続が切断されたときに呼び出されるべき処理をまとめています。
-     この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
-     いずれの場合も含めます。
-     */
+  /// 接続が切断されたときに呼び出されるべき処理をまとめています。
+  /// この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
+  /// いずれの場合も含めます。
   private func handleDisconnect() {
     // 明示的に配信をストップしてから、画面を閉じるようにしています。
     SoraSDKManager.shared.disconnect()
@@ -367,10 +355,8 @@ extension VideoChatRoomViewController {
 // MARK: - Interface Builderのための実装
 
 extension VideoChatRoomViewController {
-  /**
-     カメラボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// カメラボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
     guard let current = CameraVideoCapturer.current else {
       return
@@ -387,26 +373,20 @@ extension VideoChatRoomViewController {
     }
   }
 
-  /**
-     閉じるボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// 閉じるボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onExitButton(_ sender: UIBarButtonItem) {
     handleDisconnect()
   }
 
-  /**
-     Clear ボタンを押したときの挙動を定義します。
-     すべてのメッセージ履歴を削除します。
-     */
+  /// Clear ボタンを押したときの挙動を定義します。
+  /// すべてのメッセージ履歴を削除します。
   @IBAction func onClearButton(_ sender: Any?) {
     history = []
     updateHistoryTableView()
   }
 
-  /**
-     メッセージ送信ボタンが押されたときの挙動を定義します。
-     */
+  /// メッセージ送信ボタンが押されたときの挙動を定義します。
   @IBAction func onSendButton(_ sender: Any?) {
     guard let label = selectedLabel else {
       return
@@ -445,17 +425,13 @@ extension VideoChatRoomViewController {
     updateHistoryTableView()
   }
 
-  /**
-     画面のタップ時の挙動を定義します。
-     */
+  /// 画面のタップ時の挙動を定義します。
   @IBAction func onTapView(_ sender: UITapGestureRecognizer) {
     // キーボードが開いていれば閉じます。
     chatMessageToSendTextField.endEditing(true)
   }
 
-  /**
-     メッセージ入力キーボードのテキスト入力終了時の挙動を定義します。
-     */
+  /// メッセージ入力キーボードのテキスト入力終了時の挙動を定義します。
   @IBAction func onTextFieldDidEnd(_ sender: Any?) {
     // キーボードを閉じます。
     chatMessageToSendTextField.endEditing(true)

--- a/DecoStreamingSample/DecoStreamingSample/Classes/AVCaptureVideoOrientation+Extension.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/AVCaptureVideoOrientation+Extension.swift
@@ -3,9 +3,7 @@ import UIKit
 
 /// サンプルアプリ内で使うための、便利なExtensionを定義します。
 extension AVCaptureVideoOrientation {
-  /**
-     UIDeviceOrientationを元にAVCaptureVideoOrientationを返します。
-     */
+  /// UIDeviceOrientationを元にAVCaptureVideoOrientationを返します。
   init?(deviceOrientation: UIDeviceOrientation) {
     switch deviceOrientation {
     case .portrait: self = .portrait
@@ -16,9 +14,7 @@ extension AVCaptureVideoOrientation {
     }
   }
 
-  /**
-     UIInterfaceOrientationを元にAVCaptureVideoOrientationを返します。
-     */
+  /// UIInterfaceOrientationを元にAVCaptureVideoOrientationを返します。
   init?(interfaceOrientation: UIInterfaceOrientation) {
     switch interfaceOrientation {
     case .portrait: self = .portrait

--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift
@@ -11,18 +11,14 @@ class PublisherConfigViewController: UITableViewController {
   /// 接続試行中かどうかを表します。
   var isConnecting = false
 
-  /**
-     画面起動時の処理を記述します。
-     */
+  /// 画面起動時の処理を記述します。
   override func viewDidLoad() {
     super.viewDidLoad()
 
     channelIdTextField.text = Environment.channelId
   }
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)
@@ -98,10 +94,8 @@ class PublisherConfigViewController: UITableViewController {
     }
   }
 
-  /**
-     配信画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onUnwindToPublisherConfig(_ segue: UIStoryboardSegue) {
     // 前の画面から戻ってきても、特に処理は何も行いません。
   }

--- a/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift
@@ -140,10 +140,8 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
 
   // MARK: Actions
 
-  /**
-     カメラボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// カメラボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
     switch captureDevicePosition {
     case .front:
@@ -165,10 +163,8 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
     }
   }
 
-  /**
-     フィルタ選択ボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// フィルタ選択ボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onFilterButton(_ sender: UIBarButtonItem) {
     let alertController = UIAlertController(
       title: "フィルタを選択", message: nil, preferredStyle: .actionSheet)
@@ -181,10 +177,8 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
     present(alertController, animated: true, completion: nil)
   }
 
-  /**
-     閉じるボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// 閉じるボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onExitButton(_ sender: UIBarButtonItem?) {
     // 閉じるボタンを押してもいきなり画面を閉じるのではなく、明示的に配信をストップしてから、画面を閉じるようにしています。
     SoraSDKManager.shared.disconnect()
@@ -252,12 +246,10 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
     updateVideoOrientationUsingStatusBarOrientation()
   }
 
-  /**
-     現在のUI上のステータスバーの向きを元に、映像の回転方向を補正します。
-     こちらのメソッドはデバイスの画面が天頂向き・地面向きの状態であったとしても、ステータスバーの向きを基準に映像を回転させることができますが、
-     その代わりにデバイス画面が天頂向き・地面向きの状態で使用すると意図しない向きに画面が回ってしまう可能性もあります。
-     そこで本サンプルでは最初の1回目の補正にのみ使用しています。
-     */
+  /// 現在のUI上のステータスバーの向きを元に、映像の回転方向を補正します。
+  /// こちらのメソッドはデバイスの画面が天頂向き・地面向きの状態であったとしても、ステータスバーの向きを基準に映像を回転させることができますが、
+  /// その代わりにデバイス画面が天頂向き・地面向きの状態で使用すると意図しない向きに画面が回ってしまう可能性もあります。
+  /// そこで本サンプルでは最初の1回目の補正にのみ使用しています。
   private func updateVideoOrientationUsingStatusBarOrientation() {
     DispatchQueue.main.async {
       let statusBarOrientation = UIApplication.shared.statusBarOrientation
@@ -271,12 +263,10 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
     }
   }
 
-  /**
-     現在のデバイス自体の向きを元に、映像の回転方向を補正します。
-     こちらのメソッドはデバイスの向きを元に補正するため、デバイス画面が天頂向き・地面向きの状態で使用すると映像を回転させないで終了するようになっています。
-     （明示的にどちらかの方向にデバイスが傾けられているときにだけ、映像を回転させます）
-     そこで本サンプルではデバイスが回転したときのイベントに合わせて使用しています。
-     */
+  /// 現在のデバイス自体の向きを元に、映像の回転方向を補正します。
+  /// こちらのメソッドはデバイスの向きを元に補正するため、デバイス画面が天頂向き・地面向きの状態で使用すると映像を回転させないで終了するようになっています。
+  /// （明示的にどちらかの方向にデバイスが傾けられているときにだけ、映像を回転させます）
+  /// そこで本サンプルではデバイスが回転したときのイベントに合わせて使用しています。
   private func updateVideoOrientationUsingDeviceOrientation() {
     let deviceOrientation = UIDevice.current.orientation
     guard deviceOrientation.isPortrait || deviceOrientation.isLandscape else {
@@ -322,14 +312,12 @@ class PublisherVideoViewController: UIViewController, UIPickerViewDelegate, UIPi
 // MARK: - AVCaptureVideoDataOutputSampleBufferDelegate
 
 extension PublisherVideoViewController: AVCaptureVideoDataOutputSampleBufferDelegate {
-  /**
-     ビデオキャプチャが、新しいフレームをキャプチャしたときに呼び出されます。
-
-     このサンプルアプリでは、キャプチャされたフレームを適切に変換してSora SDKのmediaStreamに流すことで、配信を行っています。
-     注意点として、このdelegate methodはパフォーマンス維持のため、
-     メインスレッド以外のスレッド (具体的にはcaptureSessionQueue上) にて呼び出されます。
-     したがってメインスレッド上で直接操作する必要があるコードを呼び出す場合は注意が必要です。
-     */
+  /// ビデオキャプチャが、新しいフレームをキャプチャしたときに呼び出されます。
+  ///
+  /// このサンプルアプリでは、キャプチャされたフレームを適切に変換してSora SDKのmediaStreamに流すことで、配信を行っています。
+  /// 注意点として、このdelegate methodはパフォーマンス維持のため、
+  /// メインスレッド以外のスレッド (具体的にはcaptureSessionQueue上) にて呼び出されます。
+  /// したがってメインスレッド上で直接操作する必要があるコードを呼び出す場合は注意が必要です。
   func captureOutput(
     _ captureOutput: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer,
     from connection: AVCaptureConnection
@@ -366,9 +354,7 @@ extension PublisherVideoViewController: AVCaptureVideoDataOutputSampleBufferDele
     }
   }
 
-  /**
-     ビデオキャプチャが、何らかの理由でフレーム落ちしたときに呼び出されます。
-     */
+  /// ビデオキャプチャが、何らかの理由でフレーム落ちしたときに呼び出されます。
   func captureOutput(
     _ captureOutput: AVCaptureOutput, didDrop sampleBuffer: CMSampleBuffer,
     from connection: AVCaptureConnection

--- a/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
+++ b/DecoStreamingSample/DecoStreamingSample/Classes/SoraSDKManager.swift
@@ -5,21 +5,15 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  ///
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -27,12 +21,10 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  ///
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     channelId: String,
     role: Role,
@@ -71,11 +63,9 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  ///
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 .PHONY: fmt fmt-lint
 
+# デフォルトのパスを "." に設定
+TARGET_PATH ?= .
+
 # すべてを実行
 all: fmt fmt-lint
 
 # swift-format
 fmt:
-	swift format --in-place --recursive .
+	swift format --in-place --recursive $(TARGET_PATH)
 
 # swift-format lint
 fmt-lint:
-	swift format lint --strict --parallel --recursive .
-
+	swift format lint --strict --parallel --recursive $(TARGET_PATH)

--- a/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/GameViewController.swift
@@ -72,9 +72,7 @@ class GameViewController: UIViewController {
 
   // MARK: - Action
 
-  /**
-     画面タッチ時のアクションを定義します。
-     */
+  /// 画面タッチ時のアクションを定義します。
   @objc
   func onViewTapped(_ gestureRecognizer: UITapGestureRecognizer) {
     // タッチした場所に新しい箱を発生させます。
@@ -82,9 +80,7 @@ class GameViewController: UIViewController {
     addBox(at: location)
   }
 
-  /**
-     配信開始ボタンが押されたときの挙動を定義します。
-     */
+  /// 配信開始ボタンが押されたときの挙動を定義します。
   @IBAction
   func onCameraButton(_ sender: UIBarButtonItem) {
     let isConnected = (SoraSDKManager.shared.currentMediaChannel != nil)
@@ -98,9 +94,7 @@ class GameViewController: UIViewController {
     }
   }
 
-  /**
-     配信停止ボタンが押されたときの挙動を定義します。
-     */
+  /// 配信停止ボタンが押されたときの挙動を定義します。
   @IBAction
   func onPauseButton(_ sender: UIBarButtonItem) {
     let isConnected = (SoraSDKManager.shared.currentMediaChannel != nil)
@@ -112,10 +106,8 @@ class GameViewController: UIViewController {
     }
   }
 
-  /**
-     配信設定画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信設定画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction
   func onUnwindByConnect(_ segue: UIStoryboardSegue) {
     // 接続が完了して配信設定画面から戻ってきたので、画面録画を開始して配信をスタートします。
@@ -175,11 +167,9 @@ class GameViewController: UIViewController {
     updateBarButtonItems()
   }
 
-  /**
-     接続が切断されたときに呼び出されるべき処理をまとめています。
-     この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
-     いずれの場合も含めます。
-     */
+  /// 接続が切断されたときに呼び出されるべき処理をまとめています。
+  /// この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
+  /// いずれの場合も含めます。
   private func handleDisconnect() {
     // 画面録画中であれば録画を停止して、配信を切断し、ボタンの状態を更新します。
     if RPScreenRecorder.shared().isRecording {
@@ -195,10 +185,8 @@ class GameViewController: UIViewController {
     }
   }
 
-  /**
-     配信設定画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信設定画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction
   func onUnwindByExit(_ segue: UIStoryboardSegue) {
     // 単純に閉じるボタンで配信設定画面を閉じただけなので、特に処理は何も行いません。
@@ -206,9 +194,7 @@ class GameViewController: UIViewController {
 
   // MARK: - Private
 
-  /**
-     ゲーム用の実装です。指定された地点に箱を追加します。
-     */
+  /// ゲーム用の実装です。指定された地点に箱を追加します。
   private func addBox(at point: CGPoint) {
     let box = UIView(frame: CGRect(x: point.x, y: point.y, width: 64, height: 64))
     box.backgroundColor = UIColor(
@@ -220,9 +206,7 @@ class GameViewController: UIViewController {
     dynamicProperties.addItem(box)
   }
 
-  /**
-     ゲーム用の実装です。箱を削除します。
-     */
+  /// ゲーム用の実装です。箱を削除します。
   private func removeBox(_ box: UIView) {
     box.removeFromSuperview()
     gravity.removeItem(box)
@@ -230,9 +214,7 @@ class GameViewController: UIViewController {
     dynamicProperties.removeItem(box)
   }
 
-  /**
-     現在の配信状態に応じてナビゲーションバーのボタンの状態を更新します。
-     */
+  /// 現在の配信状態に応じてナビゲーションバーのボタンの状態を更新します。
   private func updateBarButtonItems() {
     let isConnected = (SoraSDKManager.shared.currentMediaChannel != nil)
     if isConnected {
@@ -246,10 +228,8 @@ class GameViewController: UIViewController {
 // MARK: - UICollisionBehaviorDelegate
 
 extension GameViewController: UICollisionBehaviorDelegate {
-  /**
-     ゲーム用の実装です。箱がバウンダリに接触したときの挙動を定義します。
-     ここでは画面外バウンダリに箱が接触したときに箱を削除しています。
-     */
+  /// ゲーム用の実装です。箱がバウンダリに接触したときの挙動を定義します。
+  /// ここでは画面外バウンダリに箱が接触したときに箱を削除しています。
   func collisionBehavior(
     _ behavior: UICollisionBehavior, beganContactFor item: UIDynamicItem,
     withBoundaryIdentifier identifier: NSCopying?, at p: CGPoint

--- a/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/PublisherConfigViewController.swift
@@ -11,18 +11,14 @@ class PublisherConfigViewController: UITableViewController {
   /// 接続試行中かどうかを表します。
   var isConnecting = false
 
-  /**
-     画面起動時の処理を記述します。
-     */
+  /// 画面起動時の処理を記述します。
   override func viewDidLoad() {
     super.viewDidLoad()
 
     channelIdTextField.text = Environment.channelId
   }
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)

--- a/ScreenCastSample/ScreenCastSample/Classes/ScreenRecorder.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/ScreenRecorder.swift
@@ -82,8 +82,9 @@ class ScreenRecorder {
         return
       }
       bitmapContext.scaleBy(x: self.inputScale, y: self.inputScale)
+      // 縦方向反転用のTransformを適用する。CGContextの座標系は左下基準なので、上下反転させる必要がある。
       bitmapContext.concatenate(
-        CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: self.inputViewSize.height))  // 縦方向反転用のTransformを適用する。CGContextの座標系は左下基準なので、上下反転させる必要がある。
+        CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: self.inputViewSize.height))
 
       // 現在のフレーム時間を計算します。
       if !(self.firstTimestamp > 0) {
@@ -118,7 +119,8 @@ class ScreenRecorder {
       return
     }
     inputViewSize = mainWindow.bounds.size
-    inputScale = 1.0  // UIScreen.main.scale のほうが良いのだが、3x Retinaのような巨大な画面で実行するとあまりにも遅すぎるので、一律1.0倍にしてます。
+    // UIScreen.main.scale のほうが良いのだが、3x Retinaのような巨大な画面で実行するとあまりにも遅すぎるので、一律1.0倍にしてます。
+    inputScale = 1.0
 
     let attributes =
       [

--- a/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
+++ b/ScreenCastSample/ScreenCastSample/Classes/SoraSDKManager.swift
@@ -5,21 +5,14 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -27,12 +20,9 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     channelId: String,
     role: Role,
@@ -71,11 +61,8 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/ConfigViewController.swift
@@ -24,12 +24,9 @@ class ConfigViewController: UITableViewController {
   /// データチャンネルシグナリング機能を有効にするためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
   @IBOutlet var dataChannelSignalingSegmentedControl: UISegmentedControl!
   /// データチャンネルシグナリング機能を有効時に WebSoket 切断を許容するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
-
   @IBOutlet var ignoreDisconnectWebSocketSegmentedControl: UISegmentedControl!
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)
@@ -130,10 +127,8 @@ class ConfigViewController: UITableViewController {
     }
   }
 
-  /**
-     配信画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onUnwindToConfig(_ segue: UIStoryboardSegue) {
     // 前の画面から戻ってきても、特に処理は何も行いません。
   }

--- a/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
+++ b/SimulcastSample/SimulcastSample/Classes/SoraSDKManager.swift
@@ -5,21 +5,14 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -27,12 +20,9 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     channelId: String,
     videoCodec: VideoCodec,
@@ -80,11 +70,8 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/SimulcastSample/SimulcastSample/Classes/VideoChatRoomViewController.swift
+++ b/SimulcastSample/SimulcastSample/Classes/VideoChatRoomViewController.swift
@@ -5,10 +5,10 @@ import UIKit
 class VideoChatRoomViewController: UIViewController {
   @IBOutlet weak var videoViewsView: UIView!
 
-  /** ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。
   private var downstreamVideoViews: [VideoView] = []
 
-  /** ビデオチャットの、配信者自身の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者自身の映像を表示するためのViewです。
   private var upstreamVideoView: VideoView?
 
   override func viewWillAppear(_ animated: Bool) {
@@ -164,9 +164,7 @@ class VideoChatRoomViewController: UIViewController {
 // MARK: - Sora SDKのイベントハンドリング
 
 extension VideoChatRoomViewController {
-  /**
-     接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
-     */
+  /// 接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
   private func handleUpdateStreams() {
     // まずはmediaPublisherのmediaStreamを取得します。
     guard (SoraSDKManager.shared.currentMediaChannel?.streams) != nil else {
@@ -221,11 +219,9 @@ extension VideoChatRoomViewController {
     layoutVideoViews(for: videoViewsView.bounds.size)
   }
 
-  /**
-     接続が切断されたときに呼び出されるべき処理をまとめています。
-     この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
-     いずれの場合も含めます。
-     */
+  /// 接続が切断されたときに呼び出されるべき処理をまとめています。
+  /// この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
+  /// いずれの場合も含めます。
   private func handleDisconnect() {
     // 明示的に配信をストップしてから、画面を閉じるようにしています。
     SoraSDKManager.shared.disconnect()
@@ -237,10 +233,8 @@ extension VideoChatRoomViewController {
 // MARK: - Interface Builderのための実装
 
 extension VideoChatRoomViewController {
-  /**
-     カメラボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// カメラボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
     guard let current = CameraVideoCapturer.current else {
       return
@@ -257,10 +251,8 @@ extension VideoChatRoomViewController {
     }
   }
 
-  /**
-     閉じるボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// 閉じるボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onExitButton(_ sender: UIBarButtonItem) {
     handleDisconnect()
   }

--- a/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/ConfigViewController.swift
@@ -36,9 +36,7 @@ class ConfigViewController: UITableViewController {
   /// データチャンネルシグナリング機能を有効時に WebSoket 切断を許容するためのコントロールです。Main.storyboardから設定されていますので、詳細はそちらをご確認ください。
   @IBOutlet var ignoreDisconnectWebSocketSegmentedControl: UISegmentedControl!
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)
@@ -167,10 +165,8 @@ class ConfigViewController: UITableViewController {
     }
   }
 
-  /**
-     配信画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onUnwindToConfig(_ segue: UIStoryboardSegue) {
     // 前の画面から戻ってきても、特に処理は何も行いません。
   }

--- a/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
+++ b/SpotlightSample/SpotlightSample/Classes/SoraSDKManager.swift
@@ -5,21 +5,14 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -27,12 +20,9 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     channelId: String,
     videoCodec: VideoCodec,
@@ -86,11 +76,8 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/SpotlightSample/SpotlightSample/Classes/VideoChatRoomViewController.swift
+++ b/SpotlightSample/SpotlightSample/Classes/VideoChatRoomViewController.swift
@@ -5,10 +5,10 @@ import UIKit
 class VideoChatRoomViewController: UIViewController {
   @IBOutlet weak var videoViewsView: UIView!
 
-  /** ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。
   private var downstreamVideoViews: [VideoView] = []
 
-  /** ビデオチャットの、配信者自身の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者自身の映像を表示するためのViewです。
   private var upstreamVideoView: VideoView?
 
   override func viewWillAppear(_ animated: Bool) {
@@ -164,9 +164,7 @@ class VideoChatRoomViewController: UIViewController {
 // MARK: - Sora SDKのイベントハンドリング
 
 extension VideoChatRoomViewController {
-  /**
-     接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
-     */
+  /// 接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
   private func handleUpdateStreams() {
     // まずはmediaPublisherのmediaStreamを取得します。
     guard (SoraSDKManager.shared.currentMediaChannel?.streams) != nil else {
@@ -221,11 +219,9 @@ extension VideoChatRoomViewController {
     layoutVideoViews(for: videoViewsView.bounds.size)
   }
 
-  /**
-     接続が切断されたときに呼び出されるべき処理をまとめています。
-     この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
-     いずれの場合も含めます。
-     */
+  /// 接続が切断されたときに呼び出されるべき処理をまとめています。
+  /// この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
+  /// いずれの場合も含めます。
   private func handleDisconnect() {
     // 明示的に配信をストップしてから、画面を閉じるようにしています。
     SoraSDKManager.shared.disconnect()
@@ -237,10 +233,8 @@ extension VideoChatRoomViewController {
 // MARK: - Interface Builderのための実装
 
 extension VideoChatRoomViewController {
-  /**
-     カメラボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// カメラボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
     guard let current = CameraVideoCapturer.current else {
       return
@@ -257,10 +251,8 @@ extension VideoChatRoomViewController {
     }
   }
 
-  /**
-     閉じるボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// 閉じるボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onExitButton(_ sender: UIBarButtonItem) {
     handleDisconnect()
   }

--- a/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/ConfigViewController.swift
@@ -24,18 +24,14 @@ class ConfigViewController: UITableViewController {
   /// 接続試行中かどうかを表します。
   var isConnecting = false
 
-  /**
-     画面起動時の処理を記述します。
-     */
+  /// 画面起動時の処理を記述します。
   override func viewDidLoad() {
     super.viewDidLoad()
     channelIdTextField.text = Environment.channelId
     h264ProfileLevelIdTextField.text = ""
   }
 
-  /**
-     行がタップされたときの処理を記述します。
-     */
+  /// 行がタップされたときの処理を記述します。
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     // まず最初にタップされた行の選択状態を解除します。
     tableView.deselectRow(at: indexPath, animated: true)
@@ -163,10 +159,8 @@ class ConfigViewController: UITableViewController {
     }
   }
 
-  /**
-     配信画面からのUnwind Segueの着地地点として定義してあります。
-     詳細はMain.storyboardの設定をご確認ください。
-     */
+  /// 配信画面からのUnwind Segueの着地地点として定義してあります。
+  /// 詳細はMain.storyboardの設定をご確認ください。
   @IBAction func onUnwindToConfig(_ segue: UIStoryboardSegue) {
     // 前の画面から戻ってきても、特に処理は何も行いません。
   }

--- a/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
+++ b/VideoChatSample/VideoChatSample/Classes/SoraSDKManager.swift
@@ -5,21 +5,15 @@ import Sora
 ///
 /// このようなクラスを用意しておくと、Sora SDKのConnectionをアプリケーション全体で一つだけ確実に管理する事が可能になるため、おすすめです。
 class SoraSDKManager {
-  /**
-     SoraSDKManagerのシングルトンインスタンスです。
-     */
+  /// SoraSDKManagerのシングルトンインスタンスです。
   static let shared = SoraSDKManager()
 
-  /**
-     現在接続中のSora SDKのMediaChannelです。
-
-     殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
-     */
+  /// 現在接続中のSora SDKのMediaChannelです。
+  ///
+  /// 殆どの場合、アプリケーション全体で一つだけ同時にMediaChannelに接続することになるので、シングルトンとして用意すると便利に使えます。
   private(set) var currentMediaChannel: MediaChannel?
 
-  /**
-     シングルトンにしたいので、イニシャライザはprivateにしてあります。
-     */
+  /// シングルトンにしたいので、イニシャライザはprivateにしてあります。
   private init() {
     // SDK のログを表示します。
     // 送受信されるシグナリングの内容や接続エラーを確認できます。
@@ -27,12 +21,10 @@ class SoraSDKManager {
     Sora.setWebRTCLogLevel(.info)
   }
 
-  /**
-     新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
-
-     既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
-     その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
-     */
+  /// 新たにSoraに接続を試みます。接続に成功した場合、currentMediaChannelが更新されます。
+  ///
+  /// 既に接続されており、currentMediaChannelが設定されている場合は新たに接続ができないようにしてあります。
+  /// その場合は、一旦先に `disconnect()` を呼び出して、現在の接続を終了してください。
   func connect(
     with configuration: Configuration,
     completionHandler: ((Error?) -> Void)?
@@ -53,11 +45,9 @@ class SoraSDKManager {
     }
   }
 
-  /**
-     既に接続済みのmediaChannelから切断します。
-
-     currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
-     */
+  /// 既に接続済みのmediaChannelから切断します。
+  ///
+  /// currentMediaChannelがnilで、まだ接続されていないときは、何もしないで終了します。
   func disconnect() {
     guard let mediaChannel = currentMediaChannel else {
       return

--- a/VideoChatSample/VideoChatSample/Classes/VideoChatRoomViewController.swift
+++ b/VideoChatSample/VideoChatSample/Classes/VideoChatRoomViewController.swift
@@ -3,10 +3,10 @@ import UIKit
 
 /// ビデオチャットを行う画面です。
 class VideoChatRoomViewController: UIViewController {
-  /** ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者以外の参加者の映像を表示するためのViewです。
   private var downstreamVideoViews: [VideoView] = []
 
-  /** ビデオチャットの、配信者自身の映像を表示するためのViewです。 */
+  /// ビデオチャットの、配信者自身の映像を表示するためのViewです。
   private var upstreamVideoView: VideoView?
 
   override func viewWillAppear(_ animated: Bool) {
@@ -162,9 +162,7 @@ class VideoChatRoomViewController: UIViewController {
 // MARK: - Sora SDKのイベントハンドリング
 
 extension VideoChatRoomViewController {
-  /**
-     接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
-     */
+  /// 接続されている配信者の数が変化したときに呼び出されるべき処理をまとめています。
   private func handleUpdateStreams() {
     // まずはmediaPublisherのmediaStreamを取得します。
     guard (SoraSDKManager.shared.currentMediaChannel?.streams) != nil else {
@@ -217,11 +215,9 @@ extension VideoChatRoomViewController {
     layoutVideoViews(for: view.bounds.size)
   }
 
-  /**
-     接続が切断されたときに呼び出されるべき処理をまとめています。
-     この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
-     いずれの場合も含めます。
-     */
+  /// 接続が切断されたときに呼び出されるべき処理をまとめています。
+  /// この切断は、能動的にこちらから切断した場合も、受動的に何らかのエラーなどが原因で切断されてしまった場合も、
+  /// いずれの場合も含めます。
   private func handleDisconnect() {
     // 明示的に配信をストップしてから、画面を閉じるようにしています。
     SoraSDKManager.shared.disconnect()
@@ -233,10 +229,8 @@ extension VideoChatRoomViewController {
 // MARK: - Interface Builderのための実装
 
 extension VideoChatRoomViewController {
-  /**
-     カメラボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// カメラボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onCameraButton(_ sender: UIBarButtonItem) {
     guard let current = CameraVideoCapturer.current else {
       return
@@ -253,10 +247,8 @@ extension VideoChatRoomViewController {
     }
   }
 
-  /**
-     閉じるボタンを押したときの挙動を定義します。
-     詳しくはMain.storyboard内の定義をご覧ください。
-     */
+  /// 閉じるボタンを押したときの挙動を定義します。
+  /// 詳しくはMain.storyboard内の定義をご覧ください。
   @IBAction func onExitButton(_ sender: UIBarButtonItem) {
     handleDisconnect()
   }


### PR DESCRIPTION
SwiftFormat から swift-format への移行対応です。

- [UPDATE] swift-format lint で出力される警告を修正
  - @zztkm
- [ADD] swift-format 実行用の Makefile を追加する
  - lint-format.sh で一括実行していたコマンドを個別に実行できるようにした
  - デフォルトでは make コマンドを実行したディレクトリから再帰的に .swift ファイルを探すが、`TARGET_PATH` 変数を与えることで特定のディレクトリ以下の .swift ファイルを対象にすることも可能

---

This pull request includes several updates across multiple files to re-enable linting checks, fix lint warnings, and improve code documentation by converting block comments to single-line comments.

### Workflow and Linting Updates:
* [`.github/workflows/data-channel-sample.yml`](diffhunk://#diff-786a1681d78fea3bcd23ea872b930cec2437692efee0b2510b8415f786cfb614L52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.
* [`.github/workflows/deco-streaming-sample.yml`](diffhunk://#diff-e3882bb6d4c27f97c42cb8a14159c9d9a614c23fd5ba5d840fad12e9fd45f20dL52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.
* [`.github/workflows/screencast-sample.yml`](diffhunk://#diff-794d3f8130943a9230ba2669111c92149ffdf64c8dfae4c7d8900ca62cea7424L52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.
* [`.github/workflows/simulcast-sample.yml`](diffhunk://#diff-60a13ce494fa185c09d33d4dfd936553c8f7881f0b111775d7653ec8924632dfL52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.
* [`.github/workflows/spotlight-sample.yml`](diffhunk://#diff-3d8340b5d1a88fcf95803b59aff7d72d0527900a483ea7ceb91215503c997a61L52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.
* [`.github/workflows/video-chat-sample.yml`](diffhunk://#diff-3b4330d4f49ff4a6d991d7d70bfd84defb72aefc2797c20265968c242a26b7d9L52-R55): Re-enabled the `fmt-lint` check by uncommenting the relevant steps.

### Documentation Improvements:
* [`DataChannelSample/DataChannelSample/ConfigViewController.swift`](diffhunk://#diff-49e77f9b2e72425735c00d5ab277990800510048ac35277ba19bf39700bc41c6L71-R78): Converted block comments to single-line comments for methods such as `viewDidLoad`, `tableView(_:didSelectRowAt:)`, `onUnwindToConfig`, `onTapTableView`, and `onTextFieldDidEnd`. [[1]](diffhunk://#diff-49e77f9b2e72425735c00d5ab277990800510048ac35277ba19bf39700bc41c6L71-R78) [[2]](diffhunk://#diff-49e77f9b2e72425735c00d5ab277990800510048ac35277ba19bf39700bc41c6L259-R270)
* [`DataChannelSample/DataChannelSample/SoraSDKManager.swift`](diffhunk://#diff-555dfd3ba4e7865530726c47c653b6bcb7cf0817c15051fbfad12c0a102275bcL8-R31): Converted block comments to single-line comments for properties and methods such as `shared`, `currentMediaChannel`, `dataChannelRandomBinary`, `init`, `connect`, and `disconnect`. [[1]](diffhunk://#diff-555dfd3ba4e7865530726c47c653b6bcb7cf0817c15051fbfad12c0a102275bcL8-R31) [[2]](diffhunk://#diff-555dfd3ba4e7865530726c47c653b6bcb7cf0817c15051fbfad12c0a102275bcL59-R51)
* [`DataChannelSample/DataChannelSample/VideoChatRoomViewController.swift`](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L24-R39): Converted block comments to single-line comments for properties and methods such as `tapGestureRecognizer`, `downstreamVideoViews`, `upstreamVideoView`, `history`, `selectedLabel`, `binaryToSend`, `handleUpdateStreams`, `handleDisconnect`, `onCameraButton`, `onExitButton`, `onClearButton`, `onSendButton`, `onTapView`, and `onTextFieldDidEnd`. [[1]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L24-R39) [[2]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L299-R291) [[3]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L354-R346) [[4]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L370-R359) [[5]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L390-R389) [[6]](diffhunk://#diff-528002b743afdad46118538730c37f8e549eff1612fdef6b27ae91d8c823b176L448-R434)
* [`DecoStreamingSample/DecoStreamingSample/Classes/AVCaptureVideoOrientation+Extension.swift`](diffhunk://#diff-c37fe4d0a139e8dfd60f803a15edbc923e656293db2812f31af727a0437062ddL6-R6): Converted block comments to single-line comments for initializers. [[1]](diffhunk://#diff-c37fe4d0a139e8dfd60f803a15edbc923e656293db2812f31af727a0437062ddL6-R6) [[2]](diffhunk://#diff-c37fe4d0a139e8dfd60f803a15edbc923e656293db2812f31af727a0437062ddL19-R17)
* [`DecoStreamingSample/DecoStreamingSample/Classes/PublisherConfigViewController.swift`](diffhunk://#diff-46e17fa3a6eba50c9620b358b0d20137f3e6f7846ec10e1323798c7f416c2a43L14-R21): Converted block comments to single-line comments for methods such as `viewDidLoad`, `tableView(_:didSelectRowAt:)`, and `onUnwindToPublisherConfig`. [[1]](diffhunk://#diff-46e17fa3a6eba50c9620b358b0d20137f3e6f7846ec10e1323798c7f416c2a43L14-R21) [[2]](diffhunk://#diff-46e17fa3a6eba50c9620b358b0d20137f3e6f7846ec10e1323798c7f416c2a43L101-R98)
* [`DecoStreamingSample/DecoStreamingSample/Classes/PublisherVideoViewController.swift`](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L143-R144): Converted block comments to single-line comments for methods such as `onCameraButton`, `onFilterButton`, `onExitButton`, `updateVideoOrientationUsingStatusBarOrientation`, `updateVideoOrientationUsingDeviceOrientation`, and `captureOutput(_:didOutput:from:)`. [[1]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L143-R144) [[2]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L168-R167) [[3]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L184-R181) [[4]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L255-R252) [[5]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L274-R269) [[6]](diffhunk://#diff-060ad2fdd66861c5de7c113d15f6e0444385c4c485dd226d8bd0601787351ce6L325-R320)

### Changelog Update:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R34-R35): Added an entry for fixing warnings output by `swift-format lint`.